### PR TITLE
Chore#28.스토리북 깃허브 pr 연결

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,41 @@
+name: Storybook Deployment
+run-name: ${{ github.actor }}의 스토리북 배포
+on:
+        pull_request:
+                branches:
+                        - develop
+jobs:
+        storybook:
+                runs-on: ubuntu-20.04
+                outputs:
+                        status: ${{ job.status }}
+                steps:
+                        - name: checkout repository
+                          uses: actions/checkout@v3
+                          with:
+                                  fetch-depth: 0
+
+                        - name: cache dependencies
+                          id: cache
+                          uses: actions/cache@v3
+                          with:
+                                  path: "**/node_modules"
+                                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-storybook
+
+                        - name: depedency install
+                          if: steps.cache.outputs.cache-hit != 'true'
+                          run: npm ci
+
+                        - name: publish to chromatic
+                          id: chromatic
+                          uses: chromaui/action@v1
+                          with:
+                                  projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+                                  token: ${{ secrets.GITHUB_TOKEN }}
+
+                        - name: comment PR
+                          uses: thollander/actions-comment-pull-request@v1
+                          env:
+                                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                          with:
+                                  message: "🚀storybook: ${{ steps.chromatic.outputs.storybookUrl }}"

--- a/package.json
+++ b/package.json
@@ -10,16 +10,15 @@
 		"preview": "vite preview",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
-		"chromaitc": "chromatic",
 		"prepare": "husky install",
 		"lint-staged": "lint-staged"
 	},
 	"lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ]
-  },
+		"src/**/*.{js,jsx,ts,tsx}": [
+			"eslint --fix",
+			"prettier --write"
+		]
+	},
 	"dependencies": {
 		"@emotion/react": "^11.11.3",
 		"@emotion/styled": "^11.11.0",


### PR DESCRIPTION
### **요약 (Summary)**

깃허브 PR에 스토리북 빌드가 자동으로 연결되도록 CI를 추가하였습니다.

### **배경 (Background)**

스토리북 변경할 때마다 개발자가 빌드하는 것은 불필요한 공수가 들기 때문에 자동화가 필요하다고 판단하였습니다.
더불어 개발자가 스토리북 빌드를 잊어도 자동화되면 다른 개발자가 확인할 수 있다는 장점도 있습니다.

### **목표 (Goals)**

- PR을 날리면 스토리북을 빌드해준다.
- 협업을 돕기 위해 스토리북의 빌드 결과 링크를 comment에 삽입해준다.

### **목표가 아닌 것 (Non-Goals)**

- 개발자가 크로마틱 빌드를 직접하지 않도록 package.json에서 chromatic 명령어를 제거하였습니다. 

### **계획 (Plan)**

**참고 링크**
- [스토리북 깃허브 pr 연결 참고 링크 - 직접 yml 파일로 추가](https://min-kyung.tistory.com/160)
- [스토리북 깃허브 pr 연결 참고 링크 - 깃허브 사이트에서 추가](https://velog.io/@tnghgks/%EC%8A%A4%ED%86%A0%EB%A6%AC%EB%B6%81-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0#%EC%8A%A4%ED%86%A0%EB%A6%AC%EB%B6%81-%EB%B0%B0%ED%8F%AC%ED%95%98%EA%B8%B0)
- 전자의 방법을 좀 더 집중하여 참고하였습니다.

**CI/CD 관련 코드 손 대본 경험이 많지 않아 불안하지만 원하던 대로 동작하지 않으면 책임지고 고치도록 하겠습니다.**

### **이외 고려 사항들 (Other Considerations)**

- github pr과 연결하기 위해선 github action을 사용해야 할 것 같습니다. 이를 위해 별도의 환경 변수 설정 대신 github secrets를 사용하였습니다.

+) 이번 PR도 마일스톤은 제거하였습니다.
