### PR TITLE
Feature#46.group order text point 컴포넌트 생성

### DIFF
--- a/src/components/atoms/GroupOrderTextPoint.tsx
+++ b/src/components/atoms/GroupOrderTextPoint.tsx
@@ -1,0 +1,15 @@
+import { getPointText } from '@utils/formatData';
+
+interface GroupOrderTextPointProps {
+	point: number;
+}
+
+function GroupOrderTextPoint({ point }: GroupOrderTextPointProps) {
+	return (
+		<span className="text-Secondary-B typography-Headline border-b-[5px] border-Secondary-B">
+			{getPointText(point)}
+		</span>
+	);
+}
+
+export default GroupOrderTextPoint;

--- a/src/components/atoms/GroupOrderTextPoint.tsx
+++ b/src/components/atoms/GroupOrderTextPoint.tsx
@@ -1,7 +1,8 @@
+import { Point } from '@models/point/entity/point';
 import { getPointText } from '@utils/formatData';
 
 interface GroupOrderTextPointProps {
-	point: number;
+	point: Point['point'];
 }
 
 function GroupOrderTextPoint({ point }: GroupOrderTextPointProps) {

--- a/src/components/atoms/ListPoint.tsx
+++ b/src/components/atoms/ListPoint.tsx
@@ -5,9 +5,9 @@ import colors from '@constants/colors';
 import { getPointText } from '@utils/formatData';
 import { Point } from '@models/point/entity/point';
 
-type ListPointProps = Pick<Point, 'point' | 'date'> & {
+interface ListPointProps extends Point {
 	onClick: () => void;
-};
+}
 
 function ListPoint({ date, point, onClick }: ListPointProps) {
 	return (

--- a/src/components/atoms/ListPoint.tsx
+++ b/src/components/atoms/ListPoint.tsx
@@ -3,12 +3,11 @@ import { Block } from 'konsta/react';
 import SvgIcon from '@assets/icons/SvgIcon';
 import colors from '@constants/colors';
 import { getPointText } from '@utils/formatData';
+import { Point } from '@models/point/entity/point';
 
-interface ListPointProps {
-	date: string;
-	point: number;
+type ListPointProps = Pick<Point, 'point' | 'date'> & {
 	onClick: () => void;
-}
+};
 
 function ListPoint({ date, point, onClick }: ListPointProps) {
 	return (

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -1,0 +1,4 @@
+export type Point = {
+	point: number;
+	date: string;
+};

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import './button.css';
 
 interface ButtonProps {

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from './Button';
 import './header.css';
 

--- a/src/stories/atoms/GroupOrderTextPoint.stories.tsx
+++ b/src/stories/atoms/GroupOrderTextPoint.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GroupOrderTextPoint from '@components/atoms/GroupOrderTextPoint';
+
+const meta = {
+	title: 'components/atoms/GroupOrderTextPoint',
+	component: GroupOrderTextPoint,
+	parameters: {
+		// More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+		layout: 'centered',
+	},
+	tags: ['autoDocs'],
+} satisfies Meta<typeof GroupOrderTextPoint>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		point: 1000,
+	},
+};

--- a/src/stories/atoms/GroupOrderTextPoint.stories.tsx
+++ b/src/stories/atoms/GroupOrderTextPoint.stories.tsx
@@ -6,7 +6,6 @@ const meta = {
 	title: 'components/atoms/GroupOrderTextPoint',
 	component: GroupOrderTextPoint,
 	parameters: {
-		// More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
 		layout: 'centered',
 	},
 	tags: ['autoDocs'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
 			"@utils/*": ["utils/*"],
 			"@stores/*": ["stores/*"],
 			"@type/*": ["type/*"],
-			"@pages/*": ["pages/*"]
+			"@pages/*": ["pages/*"],
+			"@models/*": ["models/*"]
 		},
 		"types": ["node"]
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 				replacement: '/src/constants',
 			},
 			{ find: '@stores', replacement: '/src/stores' },
+			{ find: '@models', replacement: '/src/models' },
 			{ find: '@', replacement: '/src' },
 		],
 	},


### PR DESCRIPTION
### **요약 (Summary)**

group order text point 컴포넌트를 생성하였습니다.

### **배경 (Background)**

group order text point 내부의 파란색 텍스트는 재사용될 가능성이 있다고 판단하여 컴포넌트 분리가 필요하다고 생각하였습니다.

### **목표 (Goals)**

- 피그마 디자인과 동일한 디자인의 group order text point 를 사용할 수 있다.

### **계획 (Plan)**

- 제인의 레파지토리를 참고하여 models 폴더를 생성하였습니다. -> api를 통해 받게 될 데이터를 models에서 정의하면 좋을 것 같아요!
