### PR TITLE
Feature#67.ionic router 제거

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,7 @@ import Routing from '@components/common/Routing';
 setupIonicReact();
 
 function App() {
-	return (
-		<IonApp>
-			<Routing />
-		</IonApp>
-	);
+	return <Routing />;
 }
 
 export default App;

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -1,20 +1,12 @@
-import { IonRouterOutlet } from '@ionic/react';
-import { IonReactRouter } from '@ionic/react-router';
 import { BrowserRouter, Route } from 'react-router-dom';
 
 import Home from '@pages/Home';
 
-import { buildAnimation } from '@utils/buildAnimation';
-
 function Routing() {
 	return (
-		<IonReactRouter>
-			<IonRouterOutlet animation={buildAnimation}>
-				<BrowserRouter>
-					<Route path="/home" component={Home} exact={true} />
-				</BrowserRouter>
-			</IonRouterOutlet>
-		</IonReactRouter>
+		<BrowserRouter>
+			<Route path="/home" component={Home} exact={true} />
+		</BrowserRouter>
 	);
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,5 @@
-import { IonPage } from '@ionic/react';
-
 function Home() {
-	return (
-		<IonPage
-			style={{
-				backgroundColor: 'blue',
-			}}
-		>
-			Home
-		</IonPage>
-	);
+	return <div className="bg-blue-700 text-White h-full">Home</div>;
 }
 
 export default Home;


### PR DESCRIPTION
### **요약 (Summary)**

ionic 라우터 및 관련 컴포넌트를 제거하고, 단순한 형태의 Home 페이지가 렌더링될 수 있도록 하였습니다.

### **배경 (Background)**

지난 pr에서 모바일 환경에서의 navigation을 web에서 구현하기 위해 ionic router를 설치 및 적용하였습니다. 하지만, 각각의 animation을 작업하고 적용하는 데에 공수가 꽤 들어갈 것을 고려하여 해당 기능을 우선 제거하기로 결정하였습니다. MVP 개발이 끝나면 작업의 우선순위를 따져 사용자 경험을 많이 해친다면 ionic router를 살리도록 하겠습니다.
