### PR TITLE
Feature#68.마이 페이지 작업

### DIFF
--- a/src/components/atoms/MyPage/CategoryButton.tsx
+++ b/src/components/atoms/MyPage/CategoryButton.tsx
@@ -14,7 +14,7 @@ function CategoryButton({ iconId, title, onClick }: CategoryButtonProps) {
 	return (
 		<Button
 			onClick={onClick}
-			className={`px-4 py-[15px] k-color-Gray80 text-White rounded-xl !typography-Body1 !typography-R box-content ${
+			className={`px-4 py-[15px] k-color-Gray80 text-White rounded-xl !typography-Body1 !typography-R h-[62px] ${
 				iconId ? '!justify-start' : '!justify-center'
 			} items-center w-full gap-2`}
 		>

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -1,11 +1,14 @@
 import { BrowserRouter, Route } from 'react-router-dom';
 
 import Home from '@pages/Home';
+import MyPage from '@pages/MyPage';
 
 function Routing() {
 	return (
 		<BrowserRouter>
 			<Route path="/home" component={Home} exact={true} />
+			<Route path="/" component={Home} exact={true} />
+			<Route path="/my-page" component={MyPage} exact={true} />
 		</BrowserRouter>
 	);
 }

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -7,8 +7,8 @@ function Routing() {
 	return (
 		<BrowserRouter>
 			<Route path="/home" component={Home} exact={true} />
-			<Route path="/" component={Home} exact={true} />
-			<Route path="/my-page" component={MyPage} exact={true} />
+			<Route path="/" component={Home} exact />
+			<Route path="/my-page" component={MyPage} exact />
 		</BrowserRouter>
 	);
 }

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -3,7 +3,7 @@ import LeftHomeHeader from '@components/molecules/headers/leftHeaders/LeftHomeHe
 import LeftLogoHeader from '@components/molecules/headers/leftHeaders/LeftLogoHeader';
 import RightHeader from '@components/molecules/headers/rightHeaders/RightHeader';
 
-type LeftHeaderProps = {
+export type LeftHeaderProps = {
 	leftType: 'logo' | 'back' | 'home';
 };
 

--- a/src/components/templates/PageLayout.tsx
+++ b/src/components/templates/PageLayout.tsx
@@ -1,0 +1,18 @@
+import Header, { LeftHeaderProps } from '@components/organisms/Header';
+import { ReactNode } from 'react';
+
+interface PageLayoutProps extends LeftHeaderProps {
+	children: ReactNode;
+	className?: string;
+}
+
+function PageLayout({ children, className, leftType }: PageLayoutProps) {
+	return (
+		<div>
+			<Header leftType={leftType} />
+			<div className={`px-[25px] py-3 ${className}`}>{children}</div>;
+		</div>
+	);
+}
+
+export default PageLayout;

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 
 html {
 	height: 100%;
+	background-color: #272a31;
 }
 
 body {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,12 +1,24 @@
+import { useEffect, useState } from 'react';
+
 import CategoryButton from '@components/atoms/MyPage/CategoryButton';
 import PageLayout from '@components/templates/PageLayout';
 
 function MyPage() {
+	const [userName, setUserName] = useState('홍길동');
+	useEffect(() => {
+		const userName = localStorage.getItem('userName');
+		if (userName) {
+			setUserName(userName);
+		}
+	}, []);
+
 	return (
 		<PageLayout leftType="logo">
 			<div className="text-white typography-Body2 typography-R flex flex-col gap-2 mb-6">
 				<div className="flex gap-2 items-baseline">
-					<span className="text-Secondary-B typography-Headline">홍길동</span>
+					<span className="text-Secondary-B typography-Headline">
+						{userName}
+					</span>
 					회원님
 				</div>
 				카카오톡으로 로그인되셨습니다.

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,27 @@
+import CategoryButton from '@components/atoms/MyPage/CategoryButton';
+import PageLayout from '@components/templates/PageLayout';
+
+function MyPage() {
+	return (
+		<PageLayout leftType="logo">
+			<div className="text-white typography-Body2 typography-R flex flex-col gap-2 mb-6">
+				<div className="flex gap-2 items-baseline">
+					<span className="text-Secondary-B typography-Headline">홍길동</span>
+					회원님
+				</div>
+				카카오톡으로 로그인되셨습니다.
+			</div>
+			<div className="flex flex-col gap-[15px]">
+				<CategoryButton iconId="like-full" title="찜한 목록" />
+				<CategoryButton iconId="point-paid" title="포인트" />
+				<CategoryButton iconId="mypage-person" title="포인트 환급 계좌정보" />
+				<div className="flex gap-[15px]">
+					<CategoryButton title="로그아웃" />
+					<CategoryButton title="회원 탈퇴" />
+				</div>
+			</div>
+		</PageLayout>
+	);
+}
+
+export default MyPage;


### PR DESCRIPTION
### **요약 (Summary)**

계좌 등록 / 계좌 수정 페이지로 넘어가기 전 필요한 마이 페이지를 만들었습니다.

### **목표 (Goals)**

- 라우팅 : 'my-page'를 통해 마이 페이지로 접근할 수 있다.
- 피그마의 디자인이 잘 반영되었다.

### **목표가 아닌 것 (Non-Goals)**

- 각 버튼의 동작은 아직 이후 페이지들이 구현되지 않은 관계로 구현하지 않았습니다.
- 아직 서버와의 연결이 어떻게 진행될 지 모르는 상황이라 임의로 사용자 이름을 'userName'이라고 정하고 localstorage에서 받아오는 코드로 작성하였습니다.

### **계획 (Plan)**

1. box- content
-기존 코드는 konsta에서 제공하는 버튼을 커스텀할 때 padding 값을 통해 버튼의 높이 조절이 되지 않아 box-content를 사용하였습니다.  하지만 box-content를 사용하니 부모의 container를 무시하고 그려지는 문제가 발생했습니다. 이에 height의 높이를 직접 지정하도록 코드를 변경하였는데 확장성이 부족하다고 판단되어 이후 다른 방법을 찾는다면 변경해야할 것 같습니다.
2. 웹 페이지 background
- 앱에 설정된 background color를 웹에 동일하게 적용하였습니다. 다만, 데스크탑을 위한 디자인이 따로 존재하지 않아 해당 배경을 웹 페이지 전체에 적용할지 container에만 적용할지는 추가로 팀 내 회의가 필요해보입니다. 현재는 대략적인 디자인 확인을 위해 전체에 반영해놓았습니다.
3. layout 컴포넌트 추가
- 거의 모든 페이지가 header와 content의 구성으로 이루어지고, content는 top - 12px, left/right- 25px 정도의 padding을 가지는 것을 확인할 수 있었습니다. 이를 매번 반복하여 적는 것도 능률이 떨어지고, 간격이 변경된다면 이에 대응하기 힘들다고 판단하여 일종의 layout 컴포넌트를 추가하였습니다. 이 과정에서 header의 props type이 필요하게 되어 이를 export하였습니다.
