### PR TITLE
Feature#114.상세 이미지 확대 구현

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,9 @@ import { GlobalStorybookStyles } from '../src/components/common/GlobalStorybookS
 import { loadFontsForStorybook } from '../src/utils/loadFontsForStorybook';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
 import 'tailwindcss/tailwind.css';
 loadFontsForStorybook();
 

--- a/src/components/molecules/imageSlider/LargeProductDetailImageSlider.tsx
+++ b/src/components/molecules/imageSlider/LargeProductDetailImageSlider.tsx
@@ -10,7 +10,7 @@ const LargeProductDetailImageSlider = ({
 	return (
 		<ImageSlider
 			totalImageNumber={images.length}
-			className="w-screen max-w-[600px]"
+			className="w-full max-w-[600px] !h-screen z-10"
 		>
 			{images.map((image, idx) => (
 				<div key={`Image#${idx}`}>
@@ -18,7 +18,7 @@ const LargeProductDetailImageSlider = ({
 						<img
 							src={image}
 							alt="detail large image"
-							className="w-full h-screen"
+							className="w-full h-screen object-cover"
 						/>
 					</div>
 				</div>

--- a/src/components/molecules/imageSlider/SmallProductDetailImageSlider.tsx
+++ b/src/components/molecules/imageSlider/SmallProductDetailImageSlider.tsx
@@ -2,10 +2,12 @@ import ImageSlider from '@components/atoms/ImageSlider';
 
 type SmallProductDetailImageSliderProps = {
 	images: string[];
+	handleOpenDetailImageSlider: () => void;
 };
 
 const SmallProductDetailImageSlider = ({
 	images,
+	handleOpenDetailImageSlider,
 }: SmallProductDetailImageSliderProps) => {
 	return (
 		<ImageSlider
@@ -14,7 +16,10 @@ const SmallProductDetailImageSlider = ({
 		>
 			{images.map((image, idx) => (
 				<div key={`Image#${idx}`}>
-					<div style={{ position: 'relative' }}>
+					<div
+						style={{ position: 'relative' }}
+						onClick={handleOpenDetailImageSlider}
+					>
 						<img
 							src={image}
 							alt="detail small image"

--- a/src/components/organisms/imageSlider/ImageSliderContainer.tsx
+++ b/src/components/organisms/imageSlider/ImageSliderContainer.tsx
@@ -4,13 +4,13 @@ import colors from '@constants/colors';
 
 type ImageSliderContainerProps = {
 	images: string[];
+	handleClose: () => void;
 };
 
-const ImageSliderContainer = ({ images }: ImageSliderContainerProps) => {
-	const handleCloseIconButtonClick = () => {
-		console.log('close');
-	};
-
+const ImageSliderContainer = ({
+	images,
+	handleClose,
+}: ImageSliderContainerProps) => {
 	return (
 		<div className="w-screen h-screen top-0 left-0 flex items-start justify-center overflow-hidden">
 			<LargeProductDetailImageSlider images={images} />
@@ -21,7 +21,7 @@ const ImageSliderContainer = ({ images }: ImageSliderContainerProps) => {
 						color: colors.White,
 						size: 24,
 					}}
-					onClick={handleCloseIconButtonClick}
+					onClick={handleClose}
 				/>
 			</div>
 		</div>

--- a/src/components/organisms/imageSlider/ImageSliderContainer.tsx
+++ b/src/components/organisms/imageSlider/ImageSliderContainer.tsx
@@ -1,0 +1,31 @@
+import IconButton from '@components/atoms/button/IconButton';
+import LargeProductDetailImageSlider from '@components/molecules/imageSlider/LargeProductDetailImageSlider';
+import colors from '@constants/colors';
+
+type ImageSliderContainerProps = {
+	images: string[];
+};
+
+const ImageSliderContainer = ({ images }: ImageSliderContainerProps) => {
+	const handleCloseIconButtonClick = () => {
+		console.log('close');
+	};
+
+	return (
+		<div className="w-screen h-screen top-0 left-0 flex items-start justify-center overflow-hidden">
+			<LargeProductDetailImageSlider images={images} />
+			<div className="absolute top-6 left-4 z-20">
+				<IconButton
+					icon={{
+						id: 'close',
+						color: colors.White,
+						size: 24,
+					}}
+					onClick={handleCloseIconButtonClick}
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default ImageSliderContainer;

--- a/src/components/organisms/imageSlider/ImageSliderContainer.tsx
+++ b/src/components/organisms/imageSlider/ImageSliderContainer.tsx
@@ -12,13 +12,13 @@ const ImageSliderContainer = ({
 	handleClose,
 }: ImageSliderContainerProps) => {
 	return (
-		<div className="w-screen h-screen top-0 left-0 flex items-start justify-center overflow-hidden">
+		<div className="w-screen h-screen top-0 left-0 flex items-start justify-center overflow-hidden bg-Gray60">
 			<LargeProductDetailImageSlider images={images} />
 			<div className="absolute top-6 left-4 z-20">
 				<IconButton
 					icon={{
 						id: 'close',
-						color: colors.White,
+						color: colors.Black,
 						size: 24,
 					}}
 					onClick={handleClose}

--- a/src/layouts/FixedBottomLayout.tsx
+++ b/src/layouts/FixedBottomLayout.tsx
@@ -14,7 +14,7 @@ const FixedBottomLayout = ({
 	return (
 		<>
 			<div className={`${height} w-full`} />
-			<div className="fixed bottom-5 left-2/4 -translate-x-2/4 w-full max-w-[600px] z-10">
+			<div className="fixed bottom-0 left-2/4 -translate-x-2/4 w-full max-w-[600px] z-10">
 				<div className={`w-full ${childrenPadding}`}>{children}</div>
 			</div>
 		</>

--- a/src/mocks/product.ts
+++ b/src/mocks/product.ts
@@ -17,4 +17,5 @@ export const mockProductData: Product = {
 	],
 	video: 'https://www.youtube.com/embed/8rSH8-pbHZ0',
 	url: 'https://zigzag.kr/catalog/products/127482963',
+	like: true,
 };

--- a/src/models/product/entity/product.ts
+++ b/src/models/product/entity/product.ts
@@ -8,4 +8,5 @@ export type Product = {
 	images: string[];
 	video: string;
 	url: string;
+	like: boolean;
 };

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -18,7 +18,7 @@ const ProductDetail = () => {
 		video,
 		url,
 	} = mockProductData;
-	// console.log(getYoutubeIdFromUrl(url));
+
 	return (
 		<PageLayout leftType="back">
 			<SmallProductDetailImageSlider images={images} />

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react';
+
 import BuyWithLikeButton from '@components/atoms/BuyWithLikeButton';
 import CardInfo from '@components/atoms/card/CardInfo';
 import SmallProductDetailImageSlider from '@components/molecules/imageSlider/SmallProductDetailImageSlider';
+import ImageSliderContainer from '@components/organisms/imageSlider/ImageSliderContainer';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
 import PageLayout from '@layouts/PageLayout';
 import { mockProductData } from '@mocks/product';
@@ -19,9 +22,31 @@ const ProductDetail = () => {
 		url,
 	} = mockProductData;
 
+	const [isDetailImageSliderOpen, setIsDetailImageSliderOpen] = useState(false);
+
+	const openDetailImageSlider = () => {
+		setIsDetailImageSliderOpen(true);
+	};
+
+	const closeDetailImageSlider = () => {
+		setIsDetailImageSliderOpen(false);
+	};
+
+	if (isDetailImageSliderOpen) {
+		return (
+			<ImageSliderContainer
+				handleClose={closeDetailImageSlider}
+				images={images}
+			/>
+		);
+	}
+
 	return (
 		<PageLayout leftType="back">
-			<SmallProductDetailImageSlider images={images} />
+			<SmallProductDetailImageSlider
+				images={images}
+				handleOpenDetailImageSlider={openDetailImageSlider}
+			/>
 			<div className="p-5 flex flex-col gap-5">
 				<CardInfo
 					title={title}

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -20,6 +20,7 @@ const ProductDetail = () => {
 		refund: paybackPrice,
 		video,
 		url,
+		like,
 	} = mockProductData;
 
 	const [isDetailImageSliderOpen, setIsDetailImageSliderOpen] = useState(false);
@@ -68,7 +69,7 @@ const ProductDetail = () => {
 			</div>
 			<iframe src={url} className="w-full aspect-square" />
 			<FixedBottomLayout height={'h-[96px]'} childrenPadding={'bg-Gray90'}>
-				<BuyWithLikeButton like={false} />
+				<BuyWithLikeButton like={like} />
 			</FixedBottomLayout>
 		</PageLayout>
 	);

--- a/src/stories/molecules/ProductCard.stories.tsx
+++ b/src/stories/molecules/ProductCard.stories.tsx
@@ -79,6 +79,5 @@ export const Large: Story = {
 		paybackPrice: 200000,
 		size: 'large',
 		type: 'default',
-		category: '의류',
 	},
 };

--- a/src/stories/organisms/ImageSliderContainer.stories.tsx
+++ b/src/stories/organisms/ImageSliderContainer.stories.tsx
@@ -1,0 +1,21 @@
+import ImageSliderContainer from '@components/organisms/imageSlider/ImageSliderContainer';
+import { mockImages } from '@mocks/images';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'organisms/ImageSliderContainer',
+	component: ImageSliderContainer,
+	parameters: {
+		layout: 'fullscreen',
+	},
+} satisfies Meta<typeof ImageSliderContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		images: mockImages,
+	},
+};


### PR DESCRIPTION
### **요약 (Summary)**

상품 detail 페이지에서 이미지를 클릭하면 이미지를 확대해서 볼 수 있는 기능을 구현하였습니다.

### **목표 (Goals)**

- 이미지 캐러셀을 클릭하면 이미지를 자세히 볼 수 있는 꽉 찬 화면의 캐러셀이 뜬다.
- 꽉 찬 화면의 캐러셀도 이미지를 슬라이드 하면서 확인할 수 있다.
- 좌측 상단 닫기 버튼을 통해 해당 확대 캐러셀을 닫을 수 있다.

### **목표가 아닌 것 (Non-Goals)**

- 캐러셀에서 보고 있는 이미지 번호가 그대로 확대된 이미지 캐러셀로 전달되게 하려면 꽤 복잡할 것 같아서 구현하지 않았습니다. (근데 언젠간 해야겠죠? 두렵네요)

### **계획 (Plan)**

- fixed bottom layout
디자이너님께 fixed bottom layout에 대해 여쭤본 결과 핸드폰의 safe area를 표현하기 위해 공중에 있었던것이지 실제로는 바닥에 붙어있는 것이 맞다고 합니다. 이에 해당 컴포넌트의 bottom을 0으로 변경한 상태이고 
1. 추후 앱 세팅할 때 safe area로 감싸는 작업과
2. 서비스 내에서 vh를 사용한 부분에 `dvh`나 `svh`의 적용을 전반적으로 추가해야할 것 같습니다.

- 이미지
1. 작은 버전 이미지 캐러셀은 지그재그의 모습을 흉내내었고
2. 큰 버전 이미지 캐러셀은 다음과 같이 만들었습니다.
![image](https://github.com/Central-MakeUs/Daldal-Web/assets/83866983/e748936a-fabe-4b87-a7e8-f1f4b49795b7)
: 배경은 매우 큰 화면에서는 닫기 버튼이 배경 위치에 존재하게 되면서 보이지 않아 `Gray60`의 색상을 적용하였습니다.
: 이미지 크기는 600px의 width를 지키면서도 가장 크게 그릴 수 있는 이미지를 그렸습니다.

+) 저도 해당 컴포넌트를 스토리북에서 그리려고 하면 캐러셀이 전체 스크롤로 바뀌는 문제가 발생하였습니다. 해당 문제는 캐러셀의 css 파일을 스토리북이 모르기 때문에 발생하는 에러로, preview 파일에 import 해주는 방식으로 해결할 수 있습니다!
