### PR TITLE
Refactor#112.이미지 슬라이더 리팩토링

### DIFF
--- a/src/components/atoms/ImageSlider.tsx
+++ b/src/components/atoms/ImageSlider.tsx
@@ -2,12 +2,9 @@ import { ReactNode, useState } from 'react';
 
 import Slider from 'react-slick';
 
-import '@/slick.css';
+import IndexIndicator from './IndexIndicator';
 
-type IndexIndicatorProps = {
-	currentIndex: number;
-	totalImageNumber: number;
-};
+import '@/slick.css';
 
 type ImageSliderProps = {
 	children: ReactNode;
@@ -24,23 +21,6 @@ const initOptions = {
 	dots: false,
 	autoplay: false,
 	infinite: false,
-};
-
-const IndexIndicator = ({
-	currentIndex,
-	totalImageNumber,
-}: IndexIndicatorProps) => {
-	return (
-		<div className="flex items-center gap-1 px-3 py-1 rounded-[65px] bg-black opacity-60">
-			<h6 className="text-White text-center text-xs font-semibold ">
-				{currentIndex}
-			</h6>
-			<div className="w-0.5 h-2 bg-Gray20" />
-			<h6 className="text-Gray20 text-center typography-Caption1">
-				{totalImageNumber}
-			</h6>
-		</div>
-	);
 };
 
 const ImageSlider = ({

--- a/src/components/atoms/ImageSlider.tsx
+++ b/src/components/atoms/ImageSlider.tsx
@@ -92,7 +92,7 @@ const ImageSlider = ({
 	};
 
 	return (
-		<Slider {...settings} className={`relative ${className}`}>
+		<Slider {...settings} className={`${className}`}>
 			{children}
 		</Slider>
 	);

--- a/src/components/atoms/ImageSlider.tsx
+++ b/src/components/atoms/ImageSlider.tsx
@@ -4,8 +4,6 @@ import Slider from 'react-slick';
 
 import IndexIndicator from './IndexIndicator';
 
-import '@/slick.css';
-
 type ImageSliderProps = {
 	children: ReactNode;
 	className?: string;

--- a/src/components/atoms/IndexIndicator.tsx
+++ b/src/components/atoms/IndexIndicator.tsx
@@ -1,0 +1,23 @@
+type IndexIndicatorProps = {
+	currentIndex: number;
+	totalImageNumber: number;
+};
+
+const IndexIndicator = ({
+	currentIndex,
+	totalImageNumber,
+}: IndexIndicatorProps) => {
+	return (
+		<div className="flex items-center gap-1 px-3 py-1 rounded-[65px] bg-black opacity-60">
+			<h6 className="text-White text-center text-xs font-semibold ">
+				{currentIndex}
+			</h6>
+			<div className="w-0.5 h-2 bg-Gray20" />
+			<h6 className="text-Gray20 text-center typography-Caption1">
+				{totalImageNumber}
+			</h6>
+		</div>
+	);
+};
+
+export default IndexIndicator;

--- a/src/components/molecules/bottomSheet/AccountBottomSheet.tsx
+++ b/src/components/molecules/bottomSheet/AccountBottomSheet.tsx
@@ -11,6 +11,12 @@ const AccountBottomSheet = () => {
 	if (!isBottomSheetOpen || type !== 'account') {
 		return null;
 	}
+
+	const messages = {
+		description:
+			'계좌가 등록되어 있지 않아,\n 달달한 포인트를 받기 어려워요 😥',
+		keynote: '출금 계좌를 등록해주세요!',
+	};
 	return (
 		<Drawer open={isBottomSheetOpen} onOpenChange={setBottomSheetOpen}>
 			<DrawerContent className="mx-auto w-full max-w-[600px] px-6 !h-[206px]">
@@ -24,11 +30,11 @@ const AccountBottomSheet = () => {
 					className="!w-fit absolute top-1 right-0"
 				/>
 				<div>
-					<h4 className="text-Gray60 typography-Body4 typography-M leading-normal mb-2">
-						계좌가 등록되어 있지 않아, <br /> 달달한 포인트를 받기 어려워요 😥
+					<h4 className="text-Gray60 typography-Body4 typography-M mb-2 whitespace-pre-line">
+						{messages.description}
 					</h4>
 					<h2 className="text-Black typography-Body1 typography-M">
-						출금 계좌를 등록해주세요!
+						{messages.keynote}
 					</h2>
 				</div>
 				<DefaultButton

--- a/src/components/molecules/imageSlider/SmallProductDetailImageSlider.tsx
+++ b/src/components/molecules/imageSlider/SmallProductDetailImageSlider.tsx
@@ -2,7 +2,7 @@ import ImageSlider from '@components/atoms/ImageSlider';
 
 type SmallProductDetailImageSliderProps = {
 	images: string[];
-	handleOpenDetailImageSlider: () => void;
+	handleOpenDetailImageSlider?: () => void;
 };
 
 const SmallProductDetailImageSlider = ({

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import 'slick-carousel/slick/slick.css';
 @import 'slick-carousel/slick/slick-theme.css';
+@import '@/slick.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -11,17 +11,23 @@ const ImageUpload = () => {
 		navigate(`/image-upload/${imageId}`);
 	};
 
+	const title = [
+		'사진은 꼭',
+		'제품명과 결제시간',
+		'이 나오게 업로드 부탁드립니다.',
+	];
+	const description =
+		"환급은 영업일 기준 48시간 이내에 검토되며,\n지그재그 내에서 '구매확정'을 누른 후,\n2주 이내 포인트가 환급됩니다.";
+
 	return (
 		<PageLayout leftType="back" className="px-6 py-3">
 			<div className="mb-3 flex flex-col gap-1 typography-Body1 typography-M">
-				<h1 className="text-White">사진은 꼭</h1>
-				<h1 className="text-Primary">제품명과 결제시간</h1>
-				<h1 className="text-White">이 나오게 업로드 부탁드립니다.</h1>
+				<h1 className="text-White">{title[0]}</h1>
+				<h1 className="text-Primary">{title[1]}</h1>
+				<h1 className="text-White">{title[2]}</h1>
 			</div>
-			<p className="mb-6 typography-Body4 typography-R text-Gray20">
-				환급은 영업일 기준 48시간 이내에 검토되며, <br />
-				지그재그 내에서 '구매확정'을 누른 후, <br />
-				2주 이내 포인트가 환급됩니다.
+			<p className="mb-6 typography-Body4 typography-R text-Gray20 whitespace-pre-line">
+				{description}
 			</p>
 			<div className="grid grid-cols-3 gap-[11px]">
 				<ImageUploadButton />

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react';
 
-import ImageSlider from '@components/atoms/ImageSlider';
 import ApprovedTag from '@components/atoms/tag/ApprovedTag';
 import NotApprovedTag from '@components/atoms/tag/NotApprovedTag';
 import ProgressTag from '@components/atoms/tag/ProgressTag';
+import SmallProductDetailImageSlider from '@components/molecules/imageSlider/SmallProductDetailImageSlider';
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
 import { Status } from '@type/status';
@@ -38,22 +38,7 @@ const ImageUploadDetail = () => {
 
 	return (
 		<PageLayout leftType="back">
-			<ImageSlider
-				totalImageNumber={mockImages.length}
-				className="w-screen max-w-[600px]"
-			>
-				{mockImages.map((image, idx) => (
-					<div key={`Image#${idx}`}>
-						<div style={{ position: 'relative' }}>
-							<img
-								src={image}
-								alt="detail small image"
-								className="w-full h-[350px]"
-							/>
-						</div>
-					</div>
-				))}
-			</ImageSlider>
+			<SmallProductDetailImageSlider images={mockImages} />
 			<div className="p-6 flex flex-col gap-6">
 				{renderContents('업로드 일시', dateValue())}
 				{renderContents('승인 여부', statusValue[status])}

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -7,7 +7,7 @@ import SmallProductDetailImageSlider from '@components/molecules/imageSlider/Sma
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
 import { Status } from '@type/status';
-import { getDataInYYYYMMDDSplitedByDot } from '@utils/formatData';
+import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
 
 type StatusValueType = {
 	[K in Status]: ReactNode;
@@ -21,27 +21,57 @@ const statusValue: StatusValueType = {
 
 const ImageUploadDetail = () => {
 	const date = '2023-12-12T12:12:12:32';
-	const status = 'PROGRESS';
+	const status: Status = 'APPROVED';
+	const point = '2000';
+	const approvedMessage = '어떠어떠어떠한 이유로 승인되지 않았습니다.';
 
-	const dateValue = () => (
-		<h2 className="typography-Subhead text-White">
-			{getDataInYYYYMMDDSplitedByDot(date)}
-		</h2>
+	const renderTextValue = (text: string) => (
+		<h2 className="typography-Subhead text-White">{text}</h2>
 	);
 
-	const renderContents = (title: string, value: ReactNode) => (
-		<div className="w-full flex justify-between items-center">
-			<h3 className="typography-Body2 typography-R text-Gray20">{title}</h3>
-			{value}
-		</div>
-	);
+	const renderContents = (
+		title: string,
+		value: ReactNode,
+		flex: 'row' | 'column' = 'row',
+	) => {
+		const style = {
+			row: 'flex justify-between items-center',
+			column: 'flex flex-col gap-[13px]',
+		};
+
+		return (
+			<div className={`w-full ${style[flex]}`}>
+				<h3 className="typography-Body2 typography-R text-Gray20">{title}</h3>
+				{value}
+			</div>
+		);
+	};
+
+	const renderExtraContents = () => {
+		if (status === 'APPROVED') {
+			return renderContents('승인 금액', renderTextValue(getPointText(point)));
+		} else if (status === 'NOT_APPROVED') {
+			const renderApprovedMessage = () => (
+				<h3 className="typography-Body2 typography-R text-White">
+					{approvedMessage}
+				</h3>
+			);
+			return renderContents('미승인 사유', renderApprovedMessage(), 'column');
+		} else {
+			return null;
+		}
+	};
 
 	return (
 		<PageLayout leftType="back">
 			<SmallProductDetailImageSlider images={mockImages} />
 			<div className="p-6 flex flex-col gap-6">
-				{renderContents('업로드 일시', dateValue())}
+				{renderContents(
+					'업로드 일시',
+					renderTextValue(getDataInYYYYMMDDSplitedByDot(date)),
+				)}
 				{renderContents('승인 여부', statusValue[status])}
+				{renderExtraContents()}
 			</div>
 		</PageLayout>
 	);

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from 'react';
 
+import DefaultButton from '@components/atoms/button/DefaultButton';
 import ApprovedTag from '@components/atoms/tag/ApprovedTag';
 import NotApprovedTag from '@components/atoms/tag/NotApprovedTag';
 import ProgressTag from '@components/atoms/tag/ProgressTag';
 import SmallProductDetailImageSlider from '@components/molecules/imageSlider/SmallProductDetailImageSlider';
+import FixedBottomLayout from '@layouts/FixedBottomLayout';
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
 import { Status } from '@type/status';
@@ -20,27 +22,24 @@ const statusValue: StatusValueType = {
 };
 
 const ImageUploadDetail = () => {
+	//Todo: api 응답 정보로 교체
 	const date = '2023-12-12T12:12:12:32';
 	const status: Status = 'APPROVED';
 	const point = '2000';
 	const approvedMessage = '어떠어떠어떠한 이유로 승인되지 않았습니다.';
 
+	const handleClickReApprove = () => {
+		//Todo: 승인 api 요청
+		console.log('재 승인 요청하기');
+	};
+
 	const renderTextValue = (text: string) => (
 		<h2 className="typography-Subhead text-White">{text}</h2>
 	);
 
-	const renderContents = (
-		title: string,
-		value: ReactNode,
-		flex: 'row' | 'column' = 'row',
-	) => {
-		const style = {
-			row: 'flex justify-between items-center',
-			column: 'flex flex-col gap-[13px]',
-		};
-
+	const renderContents = (title: string, value: ReactNode) => {
 		return (
-			<div className={`w-full ${style[flex]}`}>
+			<div className="w-full flex justify-between items-center">
 				<h3 className="typography-Body2 typography-R text-Gray20">{title}</h3>
 				{value}
 			</div>
@@ -51,12 +50,24 @@ const ImageUploadDetail = () => {
 		if (status === 'APPROVED') {
 			return renderContents('승인 금액', renderTextValue(getPointText(point)));
 		} else if (status === 'NOT_APPROVED') {
-			const renderApprovedMessage = () => (
-				<h3 className="typography-Body2 typography-R text-White">
-					{approvedMessage}
-				</h3>
+			return (
+				<div className="flex flex-col gap-[13px]">
+					<h3 className="typography-Body2 typography-R text-Gray20">
+						미승인 사유
+					</h3>
+					<h3 className="typography-Body2 typography-R text-White">
+						{approvedMessage}
+					</h3>
+					<FixedBottomLayout childrenPadding="px-6" height="h-15">
+						<DefaultButton
+							title="재승인 요청하기"
+							color={{ bgColor: 'White', textColor: 'Black' }}
+							size="large"
+							onClick={handleClickReApprove}
+						/>
+					</FixedBottomLayout>
+				</div>
 			);
-			return renderContents('미승인 사유', renderApprovedMessage(), 'column');
 		} else {
 			return null;
 		}

--- a/src/slick.css
+++ b/src/slick.css
@@ -27,10 +27,12 @@
 	background-color: #fff;
 }
 
+.slick-slide > div > div {
+	display: block !important;
+	max-width: 600px;
+}
+
 .slick-slide > div > div > div {
 	width: 100%;
 }
 
-.slick-slide > div > div {
-	max-width: 600px;
-}


### PR DESCRIPTION
### **요약 (Summary)**
- [x] relative 속성 제거 
- [x] 컴포넌트 분리
- [x] whitespace-pre-line 사용
- [x] 디자인 업데이트에 따른 승인 상세 페이지 추가 구현
- [x] 이미지 슬라이더 하단 6px 제거 

### **목표 (Goals)**
업데이트된 디자인을 반영하고, 코드 리뷰 피드백에 따라 리팩토링을 진행합니다.

### **목표가 아닌 것 (Non-Goals)**
포인트 상세 페이지와 구매 인증 상세 페이지가 동일하다고 명시되어 있는데, 미승인된 경우 '재승인 요청하기' 버튼의 유무가 다릅니다. 이는 내일 스프린트 회의에서 물어본 후 명확히 하도록 하겠습니다. (현재는 재승인 요청하기 버튼을 구현한 상태입니다.)


### **이외 고려 사항들 (Other Considerations)**
임의로 만든 status 변수에 'APPROVED'를 제외한 다른 타입을 넣으면 타입 에러가 납니다. (변수에 바로 값을 명시했기 때문에, 해당 변수의 타입이 값 자체가 되서 생기는 오류인 것으로 추정합니다.) 이는 추후 api 연동 시에는 자연히 해결될 것이라고 생각하여 공수를 들이지는 않았습니다.