### PR TITLE
Feature#169.상세 페이지 UI 변경 반영

### DIFF
--- a/src/assets/icons/icons.svg
+++ b/src/assets/icons/icons.svg
@@ -165,4 +165,8 @@
             </filter>
         </defs>
     </symbol>
+    <symbol id='circle-cancel' viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" fill="#17181A"/>
+        <path d="M17 8.00714L15.9929 7L12 10.9929L8.00714 7L7 8.00714L10.9929 12L7 15.9929L8.00714 17L12 13.0071L15.9929 17L17 15.9929L13.0071 12L17 8.00714Z" fill="white"/>
+    </symbol>
 </svg>

--- a/src/assets/icons/icons.svg
+++ b/src/assets/icons/icons.svg
@@ -148,4 +148,21 @@
     <svg id="plus" viewBox="0 0 32 32">
         <path d="M17 11H15V15H11V17H15V21H17V17H21V15H17V11ZM16 6C10.49 6 6 10.49 6 16C6 21.51 10.49 26 16 26C21.51 26 26 21.51 26 16C26 10.49 21.51 6 16 6ZM16 24C11.59 24 8 20.41 8 16C8 11.59 11.59 8 16 8C20.41 8 24 11.59 24 16C24 20.41 20.41 24 16 24Z" />
     </svg>
+    <symbol id="max" viewBox="0 0 25 24">
+        <g filter="url(#filter0_d_1205_237)">
+            <path d="M14.8478 6L16.4478 7.6L14.4374 9.59652L15.4252 10.5843L17.4217 8.57391L19.0217 10.1739V6H14.8478ZM6.5 10.1739L8.1 8.57391L10.0965 10.5843L11.0843 9.59652L9.07391 7.6L10.6739 6H6.5V10.1739ZM10.6739 18.5217L9.07391 16.9217L11.0843 14.9252L10.0965 13.9374L8.1 15.9478L6.5 14.3478V18.5217H10.6739ZM19.0217 14.3478L17.4217 15.9478L15.4252 13.9374L14.4374 14.9252L16.4478 16.9217L14.8478 18.5217H19.0217V14.3478Z" fill="white"/>
+        </g>
+        <defs>
+            <filter id="filter0_d_1205_237" x="5.1" y="4.6" width="15.322" height="15.322" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+            <feOffset/>
+            <feGaussianBlur stdDeviation="0.7"/>
+            <feComposite in2="hardAlpha" operator="out"/>
+            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1205_237"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1205_237" result="shape"/>
+            </filter>
+        </defs>
+    </symbol>
 </svg>

--- a/src/components/atoms/ImageSlider.tsx
+++ b/src/components/atoms/ImageSlider.tsx
@@ -33,7 +33,7 @@ const ImageSlider = ({
 	const CustomDotsAndIndexIndicator = (dots: ReactNode) => (
 		<div className="relative">
 			{!options.dots && (
-				<div className="absolute bottom-10 right-3">
+				<div className="absolute bottom-10 left-3">
 					<IndexIndicator
 						currentIndex={currentIndex}
 						totalImageNumber={totalImageNumber}

--- a/src/components/molecules/imageSlider/SmallProductDetailImageSlider.tsx
+++ b/src/components/molecules/imageSlider/SmallProductDetailImageSlider.tsx
@@ -1,8 +1,9 @@
+import { IconButton } from '@components/atoms';
 import ImageSlider from '@components/atoms/ImageSlider';
 
 type SmallProductDetailImageSliderProps = {
 	images: string[];
-	handleOpenDetailImageSlider?: () => void;
+	handleOpenDetailImageSlider: () => void;
 };
 
 const SmallProductDetailImageSlider = ({
@@ -10,25 +11,32 @@ const SmallProductDetailImageSlider = ({
 	handleOpenDetailImageSlider,
 }: SmallProductDetailImageSliderProps) => {
 	return (
-		<ImageSlider
-			totalImageNumber={images.length}
-			className="w-screen max-w-[600px]"
-		>
-			{images.map((image, idx) => (
-				<div key={`Image#${idx}`}>
-					<div
-						style={{ position: 'relative' }}
-						onClick={handleOpenDetailImageSlider}
-					>
-						<img
-							src={image}
-							alt="detail small image"
-							className="w-full h-[calc(100vw*1.2)] max-h-[654px] object-cover"
-						/>
+		<div className="relative">
+			<ImageSlider
+				totalImageNumber={images.length}
+				className="w-screen max-w-[600px]"
+			>
+				{images.map((image, idx) => (
+					<div key={`Image#${idx}`}>
+						<div style={{ position: 'relative' }}>
+							<img
+								src={image}
+								alt="detail small image"
+								className="w-full h-[calc(100vw*1.2)] max-h-[654px] object-cover"
+							/>
+						</div>
 					</div>
-				</div>
-			))}
-		</ImageSlider>
+				))}
+			</ImageSlider>
+			<IconButton
+				icon={{
+					id: 'max',
+					size: 24,
+				}}
+				onClick={handleOpenDetailImageSlider}
+				className="absolute bottom-3 right-3 !w-fit !p-0"
+			/>
+		</div>
 	);
 };
 

--- a/src/components/organisms/imageSlider/ImageSliderContainer.tsx
+++ b/src/components/organisms/imageSlider/ImageSliderContainer.tsx
@@ -1,6 +1,5 @@
 import { IconButton } from '@components/atoms';
 import { LargeProductDetailImageSlider } from '@components/molecules';
-import colors from '@constants/colors';
 
 type ImageSliderContainerProps = {
 	images: string[];
@@ -12,13 +11,12 @@ const ImageSliderContainer = ({
 	handleClose,
 }: ImageSliderContainerProps) => {
 	return (
-		<div className="w-screen h-screen top-0 left-0 flex items-start justify-center overflow-hidden bg-Gray60">
+		<div className="w-screen h-screen top-0 left-0 flex items-start justify-center overflow-hidden bg-Black">
 			<LargeProductDetailImageSlider images={images} />
 			<div className="absolute top-6 left-4 z-20">
 				<IconButton
 					icon={{
-						id: 'close',
-						color: colors.Black,
+						id: 'circle-cancel',
 						size: 24,
 					}}
 					onClick={handleClose}

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -65,8 +65,11 @@ const ProductDetail = () => {
 						className="h-full w-full rounded-s overflow-hidden"
 					/>
 				</div>
+				<iframe
+					src={url}
+					className="w-full aspect-[1/2] border-Gray60 rounded-3xl border-[7px]"
+				/>
 			</div>
-			<iframe src={url} className="w-full aspect-square" />
 			<FixedBottomLayout height={'h-[96px]'} childrenPadding={'py-3 pl-4 pr-3'}>
 				<BuyWithLikeButton like={like} />
 			</FixedBottomLayout>

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -32,6 +32,12 @@ const ProductDetail = () => {
 		setIsDetailImageSliderOpen(false);
 	};
 
+	const textWithEnter = {
+		moreTitle: '💕지그재그 내의 리뷰를 통해\n더 자세히 알아보세요!',
+		moreDescription:
+			"*구매는 '달달쇼핑' 내의 구매하기 버튼을 이용해야\n환급액을 받으실 수 있어요!",
+	};
+
 	if (isDetailImageSliderOpen) {
 		return (
 			<ImageSliderContainer
@@ -55,20 +61,31 @@ const ProductDetail = () => {
 					size="large"
 					category="의류"
 				/>
-				<div className="w-full aspect-video relative">
+				<div className="w-full relative flex flex-col gap-[10px]">
+					<h3 className="text-White typography-Body2 typography-SB">
+						❣️ 유저들의 달달한 리뷰 확인하기
+					</h3>
 					<YouTube
 						videoId={getYoutubeIdFromUrl(video)}
 						opts={{
 							height: '100%',
 							width: '100%',
 						}}
-						className="h-full w-full rounded-s overflow-hidden"
+						className="h-full aspect-video overflow-hidden"
 					/>
 				</div>
-				<iframe
-					src={url}
-					className="w-full aspect-[1/2] border-Gray60 rounded-3xl border-[7px]"
-				/>
+				<div className="whitespace-pre-line">
+					<h3 className="text-White typography-Body2 typography-SB">
+						{textWithEnter.moreTitle}
+					</h3>
+					<h6 className="text-Error mt-2 mb-3 typography-Body4 typography-R">
+						{textWithEnter.moreDescription}
+					</h6>
+					<iframe
+						src={url}
+						className="w-full aspect-[1/2] border-Gray60 rounded-3xl border-[7px]"
+					/>
+				</div>
 			</div>
 			<FixedBottomLayout height={'h-[96px]'} childrenPadding={'py-3 pl-4 pr-3'}>
 				<BuyWithLikeButton like={like} />

--- a/src/type/svgIcon.ts
+++ b/src/type/svgIcon.ts
@@ -26,7 +26,8 @@ export type IconId =
 	| 'custom-like'
 	| 'photo'
 	| 'plus'
-	| 'max';
+	| 'max'
+	| 'circle-cancel';
 
 type SvgIcon = {
 	id: IconId;

--- a/src/type/svgIcon.ts
+++ b/src/type/svgIcon.ts
@@ -25,7 +25,8 @@ export type IconId =
 	| 'baseline-apple'
 	| 'custom-like'
 	| 'photo'
-	| 'plus';
+	| 'plus'
+	| 'max';
 
 type SvgIcon = {
 	id: IconId;


### PR DESCRIPTION
### **요약 (Summary)**

상세 페이지 디자인 변경된 것 반영하였습니다.

### **목표 (Goals)**

- 이미지 슬라이더 indicator 위치 변경
- iframe border 추가
- 이미지 상세보기 slider 디자인 반영
- slider 확대 아이콘 적용 및 onClick 이벤트 반영

### **계획 (Plan)**

- 추가로 이미지 슬라이더의 현 index가 클릭하여 뜬 detail image slider의 index로 사용될 수 있도록 변경하고 싶었는데, 당장 생각나는 방법이 전역 상태 관리를 사용하는 방법밖에 없었습니다. 이미지 슬라이더 indicator의 index를 위해 전역 상태 관리를 사용하는 것이 옳을까라는 고민이 생겨서 구현하지 않았습니다. 한 번 의견 말씀해주시면 감사하겠습니다~!