### PR TITLE
Feature#181.페이지 이탈 모달

### DIFF
--- a/src/components/atoms/button/RequestLeaveModalButton.tsx
+++ b/src/components/atoms/button/RequestLeaveModalButton.tsx
@@ -11,7 +11,7 @@ const RequestLeaveModalButton = () => {
 
 	return (
 		<div
-			className="w-6 h-6 cursor-pointer py-4 bg-blue-700 fixed top-[14px] z-30"
+			className="w-6 h-6 cursor-pointer py-4 fixed top-[14px] z-30"
 			onClick={handleClickRequestLeaveModalButton}
 		/>
 	);

--- a/src/components/atoms/button/RequestLeaveModalButton.tsx
+++ b/src/components/atoms/button/RequestLeaveModalButton.tsx
@@ -1,0 +1,20 @@
+import { useModalStore } from '@stores/layerStore';
+
+const RequestLeaveModalButton = () => {
+	const { openModal } = useModalStore();
+	const handleClickRequestLeaveModalButton = (
+		e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+	) => {
+		e.preventDefault();
+		openModal('leave');
+	};
+
+	return (
+		<div
+			className="w-6 h-6 cursor-pointer py-4 bg-blue-700 fixed top-[14px] z-30"
+			onClick={handleClickRequestLeaveModalButton}
+		/>
+	);
+};
+
+export default RequestLeaveModalButton;

--- a/src/components/atoms/button/RequestLeaveModalButton.tsx
+++ b/src/components/atoms/button/RequestLeaveModalButton.tsx
@@ -1,12 +1,43 @@
+import { DefaultButton } from '@components/atoms';
 import { useModalStore } from '@stores/layerStore';
+import { useNavigate } from 'react-router-dom';
 
 const RequestLeaveModalButton = () => {
 	const { openModal } = useModalStore();
+	const navigate = useNavigate();
+
+	const goBack = () => {
+		navigate(-1);
+	};
+	const stay = () => {};
+
+	const buttons = [
+		<DefaultButton
+			color={{
+				textColor: 'White',
+				bgColor: 'Primary',
+			}}
+			title="머무르기"
+			size="small"
+			onClick={stay}
+		/>,
+		<DefaultButton
+			title="이동하기"
+			size="small"
+			color={{
+				textColor: 'Primary',
+				bgColor: 'White',
+				borderColor: 'Primary',
+			}}
+			onClick={goBack}
+		/>,
+	];
+
 	const handleClickRequestLeaveModalButton = (
 		e: React.MouseEvent<HTMLDivElement, MouseEvent>,
 	) => {
 		e.preventDefault();
-		openModal('leave');
+		openModal('leave', buttons);
 	};
 
 	return (

--- a/src/components/atoms/button/RequestLeaveModalButton.tsx
+++ b/src/components/atoms/button/RequestLeaveModalButton.tsx
@@ -42,7 +42,7 @@ const RequestLeaveModalButton = () => {
 
 	return (
 		<div
-			className="w-6 h-6 cursor-pointer py-4 fixed top-[14px] z-30"
+			className="w-7 h-6 cursor-pointer py-4 px-4 fixed top-[14px] z-30"
 			onClick={handleClickRequestLeaveModalButton}
 		/>
 	);

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -15,6 +15,7 @@ export { default as DefaultButton } from './button/DefaultButton';
 export { default as IconButton } from './button/IconButton';
 export { default as ProductCategoryButton } from './button/ProductCategoryButton';
 export { default as RequestVerificationButton } from './button/RequestVerificationButton';
+export { default as RequestLeaveModalButton } from './button/RequestLeaveModalButton';
 
 export { default as CardInfo } from './card/CardInfo';
 export { default as ImageWithCheck } from './card/ImageWithCheck';

--- a/src/components/templates/withdrawal/ProgressWithdrawal.tsx
+++ b/src/components/templates/withdrawal/ProgressWithdrawal.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@components/atoms';
+import { Form, RequestLeaveModalButton } from '@components/atoms';
 import { FormType, pointSchema } from '@type/form';
 import { useNavigate } from 'react-router-dom';
 
@@ -19,6 +19,7 @@ const ProgressWithdrawal = () => {
 				<Form.HelperText name="POINT" />
 				<Form.Button title="출금하기" />
 			</Form>
+			<RequestLeaveModalButton />
 		</div>
 	);
 };

--- a/src/pages/account/EnterAccountInfo.tsx
+++ b/src/pages/account/EnterAccountInfo.tsx
@@ -1,3 +1,4 @@
+import { RequestLeaveModalButton } from '@components/atoms';
 import PageLayout from '@layouts/PageLayout';
 import { Outlet } from 'react-router-dom';
 
@@ -5,6 +6,7 @@ const EnterAccountInfo = () => {
 	return (
 		<PageLayout leftType="back" className="px-6 py-[15px]">
 			<Outlet />
+			<RequestLeaveModalButton />
 		</PageLayout>
 	);
 };

--- a/src/pages/account/SaveAccountInfo.tsx
+++ b/src/pages/account/SaveAccountInfo.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { DefaultButton } from '@components/atoms';
+import { DefaultButton, RequestLeaveModalButton } from '@components/atoms';
 import { DisabledAccountForm } from '@components/organisms';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
 import PageLayout from '@layouts/PageLayout';
@@ -41,6 +41,7 @@ const SaveAccountInfo = () => {
 					/>
 				</FixedBottomLayout>
 			</div>
+			<RequestLeaveModalButton />
 		</PageLayout>
 	);
 };

--- a/src/stores/layerStore.tsx
+++ b/src/stores/layerStore.tsx
@@ -27,27 +27,6 @@ const modalMappingNameWithComponent = {
 	leave: {
 		title: '작성 중인 내용이 있습니다.\n나가시겠습니까?',
 		description: `해당 페이지를 벗어날 경우,\n지금까지 작성한 내용이 사라집니다.`,
-		buttons: [
-			<DefaultButton
-				color={{
-					textColor: 'White',
-					bgColor: 'Primary',
-				}}
-				title="머무르기"
-				size="small"
-				onClick={() => console.log('머무르기 클릭')}
-			/>,
-			<DefaultButton
-				title="이동하기"
-				size="small"
-				color={{
-					textColor: 'Primary',
-					bgColor: 'White',
-					borderColor: 'Primary',
-				}}
-				onClick={() => console.log('이동하기 클릭')}
-			/>,
-		],
 	},
 	cancellation: {
 		title: '정말 회원탈퇴 하시겠습니까?',
@@ -81,7 +60,7 @@ type ModalType = keyof typeof modalMappingNameWithComponent;
 type ModalStoreType = {
 	isModalOpen: boolean;
 	Modal: JSX.Element;
-	openModal: (type: ModalType) => void;
+	openModal: (type: ModalType, buttons?: JSX.Element[]) => void;
 	closeModal: () => void;
 	handleModalOpen: (open: boolean) => void;
 };
@@ -89,10 +68,12 @@ type ModalStoreType = {
 export const useModalStore = create<ModalStoreType>(set => ({
 	isModalOpen: false,
 	Modal: <></>,
-	openModal: (type: ModalType) =>
+	openModal: (type: ModalType, buttons) =>
 		set({
 			isModalOpen: true,
-			Modal: <Modal {...modalMappingNameWithComponent[type]} />,
+			Modal: (
+				<Modal {...modalMappingNameWithComponent[type]} buttons={buttons} />
+			),
 		}),
 	closeModal: () => set({ isModalOpen: false }),
 	handleModalOpen: (open: boolean) => set({ isModalOpen: open }),


### PR DESCRIPTION
### **요약 (Summary)**

일부 페이지에서 back 버튼을 클릭하면 이탈에 대해 묻는 모달이 뜨도록 구현하였습니다.

### **배경 (Background)**

이전에 브라우저 자체의 뒤로가기/새로고침까지 제어해보려 하였으나 서비스에 커스텀된 모달이 아닌, 브라우저 자체에서 제공하는 alert로 동작하였습니다. 이에 팀 내 합의를 통해 back 버튼을 클릭하였을 때에만 모달이 뜨도록 구현해보았습니다.

### **목표 (Goals)**

- 포인트 입력 화면, 계좌 정보 입력화면, 계좌 정보 입력 완료 화면에서 back 버튼을 클릭하였을 경우 모달이 뜬다.
- 모달에서 머무르기를 누르면 모달이 사라진다.
- 모달에서 이동하기를 누르면 모달이 사라지며 이전 화면으로 넘어간다.

### 계획
- 라우팅 주소를 사용하거나
- 헤더 자체에서 추가적인 props를 받을 수 있도록 변경하거나
- 전역 상태 관리 도구를 사용하는 
등의 방법을 생각해보았는데, 기존에 작성된(분리된) 코드를 건드리지 않고 코드를 작성하고 싶어 추가적인 투명 버튼을 back 버튼 자리에 위치시켜 해결하였습니다.