### PR TITLE
Feature#164.form persist 적용

### DIFF
--- a/src/stores/formInfoStore.tsx
+++ b/src/stores/formInfoStore.tsx
@@ -1,5 +1,6 @@
 import { Account } from '@models/form/entity/account';
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 type EnterType = 'EDIT' | 'REGISTER';
 
@@ -13,17 +14,25 @@ export type AccountInfoStoreType = {
 	setEnterType: (enterType: 'EDIT' | 'REGISTER') => void;
 };
 
-export const useAccountInfoStore = create<AccountInfoStoreType>(set => ({
-	accountInfo: {
-		USER: '',
-		BANK: '',
-		ACCOUNT: '',
-	} as Account,
-	setAccountInfo: accountInfo => set({ accountInfo }),
-	isSelectedBankNeeded: false,
-	setIsSelectedBankNeeded: (isSelectedBankNeeded: boolean) =>
-		set({ isSelectedBankNeeded }),
-	clearAccountInfo: () => set({ accountInfo: {} as Account }),
-	enterType: '' as EnterType,
-	setEnterType: (enterType: 'EDIT' | 'REGISTER') => set({ enterType }),
-}));
+export const useAccountInfoStore = create(
+	persist<AccountInfoStoreType>(
+		set => ({
+			accountInfo: {
+				USER: '',
+				BANK: '',
+				ACCOUNT: '',
+			} as Account,
+			setAccountInfo: accountInfo => set({ accountInfo }),
+			isSelectedBankNeeded: false,
+			setIsSelectedBankNeeded: (isSelectedBankNeeded: boolean) =>
+				set({ isSelectedBankNeeded }),
+			clearAccountInfo: () => set({ accountInfo: {} as Account }),
+			enterType: '' as EnterType,
+			setEnterType: (enterType: 'EDIT' | 'REGISTER') => set({ enterType }),
+		}),
+		{
+			name: 'form',
+			storage: createJSONStorage(() => sessionStorage),
+		},
+	),
+);

--- a/src/stores/searchHistoryStore.tsx
+++ b/src/stores/searchHistoryStore.tsx
@@ -28,7 +28,7 @@ export const useSearchHistoryStore = create(
 		}),
 		{
 			name: 'searchHistory',
-			storage: createJSONStorage(() => sessionStorage),
+			storage: createJSONStorage(() => localStorage),
 		},
 	),
 );


### PR DESCRIPTION
### **요약 (Summary)**

form 입력에 persist를 적용하였습니다.

### **배경 (Background)**

단순 전역 변수 사용만으로는 form에 대한 정보가 너무 쉽게 휘발되어 persist를 통해 storage에 저장할 수 있도록 하였습니다.

### **계획 (Plan)**

- form validation을 임의로 진행하였었는데 팀의 합의가 추가로 필요할 것 같습니다. 서버님께 문의드리도록 하겠습니다!
