### PR TITLE
Feat#214.추가 상세 페이지

### DIFF
--- a/src/components/atoms/KeyValueContainer.tsx
+++ b/src/components/atoms/KeyValueContainer.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+
+type KeyValueContainerProps = {
+	title: string;
+	value: ReactNode;
+	row?: boolean;
+};
+
+const KeyValueContainer = ({
+	title,
+	value,
+	row = true,
+}: KeyValueContainerProps) => {
+	const contentsStyle = row
+		? 'flex justify-between items-center'
+		: 'flex flex-col gap-[13px]';
+
+	return (
+		<div className={`w-full ${contentsStyle}`}>
+			<h3 className="typography-Body2 typography-R text-Gray20">{title}</h3>
+			{value}
+		</div>
+	);
+};
+
+export default KeyValueContainer;

--- a/src/components/atoms/ListPoint.tsx
+++ b/src/components/atoms/ListPoint.tsx
@@ -12,11 +12,15 @@ const ListPoint = ({
 	uploadTime,
 	refund,
 	refundStatus,
-	buyId,
+	detailId,
 }: ListPointProps) => {
 	const navigate = useNavigate();
 	const handleNavigateToDetailPage = () => {
-		navigate(`/image-upload/${buyId}`);
+		if (refundStatus === '출금') {
+			navigate(`/withdrawal-result/${detailId}`);
+		} else {
+			navigate(`/image-upload/${detailId}`);
+		}
 	};
 
 	const colorsByPoint: { [key in RefundStatus]: string } = {

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -12,6 +12,7 @@ export { default as ToastMessageLikeOrDelete } from './ToastMessageLikeOrDelete'
 export { default as SpeechBubble } from './SpeechBubble';
 export { default as Bar } from './Bar';
 export { default as BarContainer } from './BarContainer';
+export { default as KeyValueContainer } from './KeyValueContainer';
 
 export { default as CaptionButton } from './button/CaptionButton';
 export { default as DefaultButton } from './button/DefaultButton';

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -28,6 +28,7 @@ import {
 	Welcome,
 	Notification,
 	NotFound,
+	WithdrawalResult,
 } from '@pages/index';
 import { useModalStore } from '@stores/layerStore';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
@@ -62,6 +63,10 @@ const Routing = () => {
 				<Route path="/sign-up" element={<SignUp />} />
 				<Route path="/welcome" element={<Welcome />} />
 				<Route path="/notification" element={<Notification />} />
+				<Route
+					path="/withdrawal-result/:resultId"
+					element={<WithdrawalResult />}
+				/>
 
 				<Route path="/*" element={<NotFound />} />
 			</Routes>

--- a/src/components/molecules/DefaultKeyValueContainer.tsx
+++ b/src/components/molecules/DefaultKeyValueContainer.tsx
@@ -1,0 +1,19 @@
+import { KeyValueContainer } from '@components/atoms';
+
+type DefaultKeyValueContainerProps = {
+	title: string;
+	value: string;
+};
+
+const DefaultKeyValueContainer = ({
+	title,
+	value,
+}: DefaultKeyValueContainerProps) => {
+	const renderTextValue = (text: string) => (
+		<h2 className={`typography-Subhead text-White`}>{text}</h2>
+	);
+
+	return <KeyValueContainer title={title} value={renderTextValue(value)} />;
+};
+
+export default DefaultKeyValueContainer;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -3,6 +3,7 @@ export { default as ImageContainer } from './ImageContainer';
 export { default as ProductCard } from './ProductCard';
 export { default as ProgressBar } from './ProgressBar';
 export { default as WithdrawOrNotButton } from './WithdrawOrNotButton';
+export { default as DefaultKeyValueContainer } from './DefaultKeyValueContainer';
 
 export { default as AccountBottomSheet } from './bottomSheet/AccountBottomSheet';
 export { default as BankBottomSheet } from './bottomSheet/BankBottomSheet';

--- a/src/mocks/mockWithdrawalResult.ts
+++ b/src/mocks/mockWithdrawalResult.ts
@@ -1,0 +1,17 @@
+type MockWithdrawalResultType = {
+	requestDate: string;
+	approvedDate: string;
+	prevPoint: string;
+	requestPoint: string;
+	remainedPoint: string;
+};
+
+const mockWithdrawalResult: MockWithdrawalResultType = {
+	requestDate: '2023-12-12T12:12:12:32',
+	approvedDate: '2023-12-22T23:16:12:32',
+	prevPoint: '3000',
+	requestPoint: '1000',
+	remainedPoint: '2000',
+};
+
+export default mockWithdrawalResult;

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -4,7 +4,7 @@ export type RefundStatus = '진행중' | '미승인' | '승인' | '출금';
 export type PointHistory = {
 	refund?: Point;
 	uploadTime: string;
-	buyId: number;
+	detailId: number;
 	refundStatus: RefundStatus;
 };
 

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -1,7 +1,15 @@
 import { ReactNode } from 'react';
 
-import { ApprovedTag, NotApprovedTag, ProgressTag } from '@components/atoms';
-import { SmallProductDetailImageSlider } from '@components/molecules';
+import {
+	ApprovedTag,
+	KeyValueContainer,
+	NotApprovedTag,
+	ProgressTag,
+} from '@components/atoms';
+import {
+	DefaultKeyValueContainer,
+	SmallProductDetailImageSlider,
+} from '@components/molecules';
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
 import { Status } from '@type/status';
@@ -28,34 +36,22 @@ const ImageUploadDetail = () => {
 		<h2 className={`${typography} text-White`}>{text}</h2>
 	);
 
-	const renderContents = (
-		title: string,
-		value: ReactNode,
-		row: boolean = true,
-	) => {
-		const contentsStyle = row
-			? 'flex justify-between items-center'
-			: 'flex flex-col gap-[13px]';
-
-		return (
-			<div className={`w-full ${contentsStyle}`}>
-				<h3 className="typography-Body2 typography-R text-Gray20">{title}</h3>
-				{value}
-			</div>
-		);
-	};
-
 	const renderExtraContents = () => {
 		if (status === 'APPROVED') {
-			return renderContents(
-				'승인 금액',
-				renderTextValue(getPointText(point), 'typography-Subhead'),
+			return (
+				<DefaultKeyValueContainer
+					title="승인 금액"
+					value={getPointText(point)}
+				/>
 			);
 		} else if (status === 'NOT_APPROVED') {
-			return renderContents(
-				'미승인 사유',
-				renderTextValue(approvedMessage, 'typography-Body2 typography-R'),
-				false,
+			const textValue = renderTextValue(
+				approvedMessage,
+				'typography-Body2 typography-R',
+			);
+
+			return (
+				<KeyValueContainer title="미승인 사유" value={textValue} row={false} />
 			);
 		} else {
 			return null;
@@ -66,14 +62,11 @@ const ImageUploadDetail = () => {
 		<PageLayout leftType="back">
 			<SmallProductDetailImageSlider images={mockImages} />
 			<div className="p-6 flex flex-col gap-6">
-				{renderContents(
-					'업로드 일시',
-					renderTextValue(
-						getDataInYYYYMMDDSplitedByDot(date),
-						'typography-Subhead',
-					),
-				)}
-				{renderContents('승인 여부', statusValue[status])}
+				<DefaultKeyValueContainer
+					title="업로드 일시"
+					value={getDataInYYYYMMDDSplitedByDot(date)}
+				/>
+				<KeyValueContainer title="승인 여부" value={statusValue[status]} />
 				{renderExtraContents()}
 			</div>
 		</PageLayout>

--- a/src/pages/WithdrawalResult.tsx
+++ b/src/pages/WithdrawalResult.tsx
@@ -1,5 +1,33 @@
+import { DefaultKeyValueContainer } from '@components/index';
+import PageLayout from '@layouts/PageLayout';
+import mockWithdrawalResult from '@mocks/mockWithdrawalResult';
+import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
+
 const WithdrawalResult = () => {
-	return <div>WithdrawalResult</div>;
+	return (
+		<PageLayout className="px-6 py-5 flex flex-col gap-6" leftType="back">
+			<DefaultKeyValueContainer
+				title="환금 요청 일시"
+				value={getDataInYYYYMMDDSplitedByDot(mockWithdrawalResult.requestDate)}
+			/>
+			<DefaultKeyValueContainer
+				title="환금 승인 일시"
+				value={getDataInYYYYMMDDSplitedByDot(mockWithdrawalResult.approvedDate)}
+			/>
+			<DefaultKeyValueContainer
+				title="환급 전 누적포인트"
+				value={getPointText(mockWithdrawalResult.prevPoint)}
+			/>
+			<DefaultKeyValueContainer
+				title="요청 포인트"
+				value={getPointText(mockWithdrawalResult.requestPoint)}
+			/>
+			<DefaultKeyValueContainer
+				title="잔여 포인트"
+				value={getPointText(mockWithdrawalResult.remainedPoint)}
+			/>
+		</PageLayout>
+	);
 };
 
 export default WithdrawalResult;

--- a/src/pages/WithdrawalResult.tsx
+++ b/src/pages/WithdrawalResult.tsx
@@ -1,0 +1,5 @@
+const WithdrawalResult = () => {
+	return <div>WithdrawalResult</div>;
+};
+
+export default WithdrawalResult;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -16,3 +16,4 @@ export { default as SignUp } from './SignUp';
 export { default as Welcome } from './Welcome';
 export { default as Notification } from './Notification';
 export { default as NotFound } from './NotFound';
+export { default as WithdrawalResult } from './WithdrawalResult';


### PR DESCRIPTION
### **요약 (Summary)**
포인트 페이지에서 출금 버튼을 클릭한 경우, 보여질 상세 페이지를 제작하였습니다.

### **목표 (Goals)**
출금 버튼 클릭 시 환급 상세페이지로, 그 외 버튼(승인, 미승인, 진행중) 클릭 시 구매 인증 상세 페이지로 라우팅되도록 합니다.

### **계획 (Plan)**
기존의 buyId는 구매인증 상세페이지의 id에만 해당되는 느낌을 받아서, detailId로 파라미터명을 수정하였습니다.
그리고 기존 ImageUploadDetail에서 사용된 컴포넌트와 비슷한 부분이 많아 atom으로 확장성을 고려한 컴포넌트를 제작하였고, 기존 코드도 리팩토링을 진행하였습니다.