### PR TITLE
Feat#228.포인트 및 인증 api 연동

### DIFF
--- a/src/apis/imageUpload.ts
+++ b/src/apis/imageUpload.ts
@@ -1,0 +1,11 @@
+import { ImageUploadSimpleListDTO } from '@models/imageUpload/response/ImageUploadSimpleListDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+import { api } from '.';
+
+export const getImageUploadSimpleList = async (): Promise<
+	ApiResponse<ImageUploadSimpleListDTO>
+> => {
+	const response = await api.get('/api/v1/buys/me');
+	return response.data;
+};

--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -17,3 +17,10 @@ export const getExpectedPoint = async (): Promise<
 	const response = await api.get('/api/v1/points/history/expect');
 	return response.data;
 };
+
+export const getCumulatedPoint = async (): Promise<
+	ApiResponse<PointHistoryResponseDTO>
+> => {
+	const response = await api.get('/api/v1/points/history/cumulate');
+	return response.data;
+};

--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -1,0 +1,11 @@
+import { ProductDetailListResponseDTO } from '@models/product/response/productDetailListResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+import { api } from '.';
+
+export const getCurrentPoint = async (): Promise<
+	ApiResponse<ProductDetailListResponseDTO>
+> => {
+	const response = await api.get('/api/v1/points/me');
+	return response.data;
+};

--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -1,10 +1,10 @@
-import { ProductDetailListResponseDTO } from '@models/product/response/productDetailListResponseDTO';
+import { CurrentPointResponseDTO } from '@models/point/response/currentPointResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 import { api } from '.';
 
 export const getCurrentPoint = async (): Promise<
-	ApiResponse<ProductDetailListResponseDTO>
+	ApiResponse<CurrentPointResponseDTO>
 > => {
 	const response = await api.get('/api/v1/points/me');
 	return response.data;

--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -1,4 +1,5 @@
 import { CurrentPointResponseDTO } from '@models/point/response/currentPointResponseDTO';
+import { PointHistoryResponseDTO } from '@models/point/response/pointHistoryResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 import { api } from '.';
@@ -7,5 +8,12 @@ export const getCurrentPoint = async (): Promise<
 	ApiResponse<CurrentPointResponseDTO>
 > => {
 	const response = await api.get('/api/v1/points/me');
+	return response.data;
+};
+
+export const getExpectedPoint = async (): Promise<
+	ApiResponse<PointHistoryResponseDTO>
+> => {
+	const response = await api.get('/api/v1/points/history/expect');
 	return response.data;
 };

--- a/src/components/atoms/ListPoint.tsx
+++ b/src/components/atoms/ListPoint.tsx
@@ -2,7 +2,9 @@ import { Block, Button } from 'konsta/react';
 
 import { SvgIcon } from '@components/common';
 import colors from '@constants/colors';
-import { PointHistory, MockRefundStatus } from '@models/point/entity/point';
+import koRefundStatus from '@constants/koRefundStatus';
+import { PointHistory } from '@models/point/entity/point';
+import { KoRefundStatus } from '@type/refundStatus';
 import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
 import { useNavigate } from 'react-router-dom';
 
@@ -12,18 +14,20 @@ const ListPoint = ({
 	uploadTime,
 	refund,
 	refundStatus,
-	buyId,
+	id,
 }: ListPointProps) => {
 	const navigate = useNavigate();
+
+	const covertedRefundStatus = koRefundStatus[refundStatus];
 	const handleNavigateToDetailPage = () => {
-		if (refundStatus === '출금') {
-			navigate(`/withdrawal-result/${buyId}`);
+		if (covertedRefundStatus === '출금') {
+			navigate(`/withdrawal-result/${id}`);
 		} else {
-			navigate(`/image-upload/${buyId}`);
+			navigate(`/image-upload/${id}`);
 		}
 	};
 
-	const colorsByPoint: { [key in MockRefundStatus]: string } = {
+	const colorsByPoint: { [key in KoRefundStatus]: string } = {
 		미승인: 'text-Error',
 		진행중: 'text-Secondary_B',
 		승인: 'text-Gray20',
@@ -42,9 +46,9 @@ const ListPoint = ({
 						{getDataInYYYYMMDDSplitedByDot(uploadTime)}
 					</span>
 					<span
-						className={`typography-Body2 typography-R ${colorsByPoint[refundStatus]}`}
+						className={`typography-Body2 typography-R ${colorsByPoint[covertedRefundStatus]}`}
 					>
-						{getPointText(refund, refundStatus)}
+						{getPointText(refund, covertedRefundStatus)}
 					</span>
 				</Block>
 			</Block>

--- a/src/components/atoms/ListPoint.tsx
+++ b/src/components/atoms/ListPoint.tsx
@@ -2,7 +2,7 @@ import { Block, Button } from 'konsta/react';
 
 import { SvgIcon } from '@components/common';
 import colors from '@constants/colors';
-import { PointHistory, RefundStatus } from '@models/point/entity/point';
+import { PointHistory, MockRefundStatus } from '@models/point/entity/point';
 import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
 import { useNavigate } from 'react-router-dom';
 
@@ -23,7 +23,7 @@ const ListPoint = ({
 		}
 	};
 
-	const colorsByPoint: { [key in RefundStatus]: string } = {
+	const colorsByPoint: { [key in MockRefundStatus]: string } = {
 		미승인: 'text-Error',
 		진행중: 'text-Secondary_B',
 		승인: 'text-Gray20',

--- a/src/components/molecules/CategoryButtonList.tsx
+++ b/src/components/molecules/CategoryButtonList.tsx
@@ -1,23 +1,9 @@
 import { ProductCategoryButton } from '@components/atoms';
-import { IconId } from '@type/svgIcon';
+import categoryList from '@constants/categoryList';
 import { useNavigate } from 'react-router-dom';
 
 const CategoryButtonList = () => {
-	const categoyList: {
-		id: IconId;
-		name: string;
-		route: string;
-	}[] = [
-		{ id: 'category-lotion', name: '로션', route: '/category/lotion' },
-		{ id: 'category-base', name: '베이스', route: '/category/base' },
-		{ id: 'category-eye', name: '아이', route: '/category/eye' },
-		{ id: 'category-lip', name: '립', route: '/category/lip' },
-		{
-			id: 'category-innerBeauty',
-			name: '이너뷰티',
-			route: '/category/innerBeauty',
-		},
-	];
+	const categoyValueList = Object.values(categoryList);
 
 	const navigate = useNavigate();
 	const handleCategoryButtonClick = (route: string) => {
@@ -26,7 +12,7 @@ const CategoryButtonList = () => {
 
 	return (
 		<div className="flex justify-between py-3 px-6 my-2 bg-Gray80">
-			{categoyList.map(({ name, id, route }, index) => {
+			{categoyValueList.map(({ name, id, route }, index) => {
 				return (
 					<ProductCategoryButton
 						key={`CategoryButton#${index}`}

--- a/src/components/molecules/ImageContainer.tsx
+++ b/src/components/molecules/ImageContainer.tsx
@@ -1,9 +1,9 @@
 import { ApprovedTag, NotApprovedTag, ProgressTag } from '@components/atoms';
-import { Status } from '@type/status';
+import { RefundStatus } from '@type/refundStatus';
 
 type ImageContainerProps = {
 	imageUrl: string;
-	status: Status;
+	status: RefundStatus;
 	onClick: () => void;
 };
 
@@ -15,9 +15,9 @@ const ImageContainer = ({ imageUrl, status, onClick }: ImageContainerProps) => {
 				className="w-full relative rounded-[5px] object-cover aspect-square"
 			/>
 			<div className="absolute top-1 right-1">
-				{status === 'APPROVED' && <ApprovedTag size="small" />}
-				{status === 'PROGRESS' && <ProgressTag size="small" />}
-				{status === 'NOT_APPROVED' && <NotApprovedTag size="small" />}
+				{status === 'COMPLETED' && <ApprovedTag size="small" />}
+				{status === 'IN_PROGRESS' && <ProgressTag size="small" />}
+				{status === 'REJECTED' && <NotApprovedTag size="small" />}
 			</div>
 		</div>
 	);

--- a/src/components/molecules/point/PointHeader.tsx
+++ b/src/components/molecules/point/PointHeader.tsx
@@ -2,17 +2,16 @@ import {
 	GroupOrderTextPoint,
 	RequestVerificationButton,
 } from '@components/atoms';
-import { Point } from '@models/point/entity/point';
+import { useGetCurrentPoint } from '@hooks/apis/point';
 
 const PointHeader = () => {
-	// TODO: totalPoint API 연동
-	const totalPoint: Point = '10000';
+	const { data: totalPoint } = useGetCurrentPoint();
 
 	return (
 		<div className="flex justify-between items-end mb-7">
 			<div className="typography-Body1 typography-R text-White">
 				회원님의 현재 포인트는 <br />
-				<GroupOrderTextPoint point={totalPoint} /> 입니다.
+				<GroupOrderTextPoint point={String(totalPoint)} /> 입니다.
 			</div>
 			<RequestVerificationButton />
 		</div>

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -7,7 +7,7 @@ export { default as DisabledAccountForm } from './form/DisabledAccountForm';
 
 export { default as ImageSliderContainer } from './imageSlider/ImageSliderContainer';
 
-export { default as CurrentPointHistory } from './point/CurrentPointHistory';
-export { default as PastPointHistory } from './point/PastPointHistory';
+export { default as ExpectedPointHistory } from './point/ExpectedPointHistory';
+export { default as CumulatedPointHistory } from './point/CumulatedPointHistory';
 
 export { default as RecentSearchListContainer } from './RecentSearchListContainer';

--- a/src/components/organisms/point/CumulatedPointHistory.tsx
+++ b/src/components/organisms/point/CumulatedPointHistory.tsx
@@ -5,20 +5,17 @@ import {
 	PointHistoryTitle,
 } from '@components/molecules';
 import { useGetCumulatedPoint } from '@hooks/apis/point';
-//import { mockPastPointHistory } from '@mocks/pointList';
 
 const CumulatedPointHistory = () => {
-	// TODO: Past Point History get api 연결
 	const { data: pointList } = useGetCumulatedPoint();
-	//const pointList = mockPastPointHistory;
 
 	const title = '역대 누적 포인트';
 
 	return (
 		<PointHistory>
 			<PointHistoryTitle title={title} />
-			<HistoryTotalPoint totalPoint={pointList.totalPoint} />
-			<PointList {...pointList} />
+			<HistoryTotalPoint totalPoint={String(pointList.totalPoint)} />
+			<PointList pointList={pointList.buyResponses} />
 		</PointHistory>
 	);
 };

--- a/src/components/organisms/point/CumulatedPointHistory.tsx
+++ b/src/components/organisms/point/CumulatedPointHistory.tsx
@@ -7,7 +7,7 @@ import {
 import { useGetCumulatedPoint } from '@hooks/apis/point';
 //import { mockPastPointHistory } from '@mocks/pointList';
 
-const PastPointHistory = () => {
+const CumulatedPointHistory = () => {
 	// TODO: Past Point History get api 연결
 	const { data: pointList } = useGetCumulatedPoint();
 	//const pointList = mockPastPointHistory;
@@ -23,4 +23,4 @@ const PastPointHistory = () => {
 	);
 };
 
-export default PastPointHistory;
+export default CumulatedPointHistory;

--- a/src/components/organisms/point/CurrentPointHistory.tsx
+++ b/src/components/organisms/point/CurrentPointHistory.tsx
@@ -4,11 +4,13 @@ import {
 	PointList,
 	PointHistoryTitle,
 } from '@components/molecules';
-import { mockCurrentPointHistory } from '@mocks/pointList';
+import { useGetExpectedPoint } from '@hooks/apis/point';
+//import { mockCurrentPointHistory } from '@mocks/pointList';
 
 const CurrentPointHistory = () => {
 	// TODO: current Point History get api 연결
-	const pointList = mockCurrentPointHistory;
+	const { data: pointList } = useGetExpectedPoint();
+	//const pointList = mockCurrentPointHistory;
 
 	const title = '이번달 예상 누적 포인트';
 	const description =

--- a/src/components/organisms/point/ExpectedPointHistory.tsx
+++ b/src/components/organisms/point/ExpectedPointHistory.tsx
@@ -7,7 +7,7 @@ import {
 import { useGetExpectedPoint } from '@hooks/apis/point';
 //import { mockCurrentPointHistory } from '@mocks/pointList';
 
-const CurrentPointHistory = () => {
+const ExpectedPointHistory = () => {
 	// TODO: current Point History get api 연결
 	const { data: pointList } = useGetExpectedPoint();
 	//const pointList = mockCurrentPointHistory;
@@ -25,4 +25,4 @@ const CurrentPointHistory = () => {
 	);
 };
 
-export default CurrentPointHistory;
+export default ExpectedPointHistory;

--- a/src/components/organisms/point/ExpectedPointHistory.tsx
+++ b/src/components/organisms/point/ExpectedPointHistory.tsx
@@ -5,12 +5,9 @@ import {
 	PointHistoryTitle,
 } from '@components/molecules';
 import { useGetExpectedPoint } from '@hooks/apis/point';
-//import { mockCurrentPointHistory } from '@mocks/pointList';
 
 const ExpectedPointHistory = () => {
-	// TODO: current Point History get api 연결
 	const { data: pointList } = useGetExpectedPoint();
-	//const pointList = mockCurrentPointHistory;
 
 	const title = '이번달 예상 누적 포인트';
 	const description =
@@ -19,8 +16,8 @@ const ExpectedPointHistory = () => {
 	return (
 		<PointHistory>
 			<PointHistoryTitle title={title} description={description} />
-			<HistoryTotalPoint totalPoint={pointList.totalPoint} />
-			<PointList {...pointList} />
+			<HistoryTotalPoint totalPoint={String(pointList.totalPoint)} />
+			<PointList pointList={pointList.buyResponses} />
 		</PointHistory>
 	);
 };

--- a/src/components/organisms/point/PastPointHistory.tsx
+++ b/src/components/organisms/point/PastPointHistory.tsx
@@ -4,11 +4,13 @@ import {
 	PointList,
 	PointHistoryTitle,
 } from '@components/molecules';
-import { mockPastPointHistory } from '@mocks/pointList';
+import { useGetCumulatedPoint } from '@hooks/apis/point';
+//import { mockPastPointHistory } from '@mocks/pointList';
 
 const PastPointHistory = () => {
 	// TODO: Past Point History get api 연결
-	const pointList = mockPastPointHistory;
+	const { data: pointList } = useGetCumulatedPoint();
+	//const pointList = mockPastPointHistory;
 
 	const title = '역대 누적 포인트';
 

--- a/src/constants/categoryList.ts
+++ b/src/constants/categoryList.ts
@@ -1,20 +1,22 @@
 import { IconId } from '@type/svgIcon';
 
-export type CategoryName = 'lotion' | 'base' | 'eye' | 'lip' | 'innerBeauty';
+export type CategoryName = 'TOPS' | 'BOTTOMS' | 'FASHION' | 'BEAUTY' | 'ETC';
 
 type CategoryList = {
 	[K in CategoryName]: {
 		id: IconId;
 		name: string;
+		route: string;
 	};
 };
 
 const categoryList: CategoryList = {
-	lotion: { id: 'category-lotion', name: '로션' },
-	base: { id: 'category-base', name: '베이스' },
-	eye: { id: 'category-eye', name: '아이' },
-	lip: { id: 'category-lip', name: '립' },
-	innerBeauty: { id: 'category-innerBeauty', name: '이너뷰티' },
+	//TODO 디자인 업데이트 시 id, name 변경
+	TOPS: { id: 'category-lotion', name: '로션', route: '/category/TOPS' },
+	BOTTOMS: { id: 'category-base', name: '베이스', route: '/category/BOTTOMS' },
+	FASHION: { id: 'category-eye', name: '아이', route: '/category/FASHION' },
+	BEAUTY: { id: 'category-lip', name: '립', route: '/category/BEAUTY' },
+	ETC: { id: 'category-innerBeauty', name: '이너뷰티', route: '/category/ETC' },
 };
 
 export default categoryList;

--- a/src/constants/koRefundStatus.tsx
+++ b/src/constants/koRefundStatus.tsx
@@ -1,0 +1,8 @@
+const koRefundStatus = {
+	IN_PROGRESS: '진행중',
+	COMPLETED: '승인',
+	REJECTED: '미승인',
+	WITHDRAWN: '출금',
+} as const;
+
+export default koRefundStatus;

--- a/src/hooks/apis/auth.ts
+++ b/src/hooks/apis/auth.ts
@@ -1,7 +1,7 @@
 import { getUserInfo, kakaoLogin, logout } from '@apis/auth';
 import { LogoutRequestDTO } from '@models/auth/request/logoutRequestDTO';
 import { TokenResponseDTO } from '@models/auth/response/tokenResponseDTO';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { ApiResponse } from '@type/apiResponse';
 import {
 	removeAccessToken,
@@ -49,10 +49,13 @@ export const useLogout = (
 	});
 };
 
-export const useGetUserInfo = () => {
-	return useSuspenseQuery({
-		queryKey: ['userInfo'],
-		queryFn: () => getUserInfo(),
-		select: data => data.data,
+export const useGetUserInfo = (errorCallback?: (error: Error) => void) => {
+	return useMutation({
+		mutationFn: () => getUserInfo(),
+		onSuccess: userInfo => {
+			setUserName(userInfo.data.name);
+			setProvider(userInfo.data.provider);
+		},
+		onError: errorCallback,
 	});
 };

--- a/src/hooks/apis/imageUpload.ts
+++ b/src/hooks/apis/imageUpload.ts
@@ -1,0 +1,10 @@
+import { getImageUploadSimpleList } from '@apis/imageUpload';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useGetImageUploadSimpleList = () => {
+	return useSuspenseQuery({
+		queryKey: ['imageUploadSimpleList'],
+		queryFn: () => getImageUploadSimpleList(),
+		select: data => data.data,
+	});
+};

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -1,4 +1,8 @@
-import { getCurrentPoint, getExpectedPoint } from '@apis/point';
+import {
+	getCumulatedPoint,
+	getCurrentPoint,
+	getExpectedPoint,
+} from '@apis/point';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetCurrentPoint = () => {
@@ -13,6 +17,14 @@ export const useGetExpectedPoint = () => {
 	return useSuspenseQuery({
 		queryKey: ['expectedPoint'],
 		queryFn: () => getExpectedPoint(),
+		select: data => data.data,
+	});
+};
+
+export const useGetCumulatedPoint = () => {
+	return useSuspenseQuery({
+		queryKey: ['cumulatedPoint'],
+		queryFn: () => getCumulatedPoint(),
 		select: data => data.data,
 	});
 };

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -1,10 +1,18 @@
-import { getCurrentPoint } from '@apis/point';
+import { getCurrentPoint, getExpectedPoint } from '@apis/point';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetCurrentPoint = () => {
 	return useSuspenseQuery({
 		queryKey: ['currentPoint'],
 		queryFn: () => getCurrentPoint(),
+		select: data => data.data,
+	});
+};
+
+export const useGetExpectedPoint = () => {
+	return useSuspenseQuery({
+		queryKey: ['expectedPoint'],
+		queryFn: () => getExpectedPoint(),
 		select: data => data.data,
 	});
 };

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -1,0 +1,10 @@
+import { getCurrentPoint } from '@apis/point';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useGetCurrentPoint = () => {
+	return useSuspenseQuery({
+		queryKey: ['currentPoint'],
+		queryFn: () => getCurrentPoint(),
+		select: data => data.data,
+	});
+};

--- a/src/mocks/pointList.ts
+++ b/src/mocks/pointList.ts
@@ -11,19 +11,19 @@ export const mockCurrentPointHistory: MockPointHistory = {
 		{
 			refund: '1000',
 			uploadTime: '2021-09-23T15:00:00.000Z',
-			buyId: 1,
-			refundStatus: '승인',
+			id: 1,
+			refundStatus: 'COMPLETED',
 		},
 		{
 			uploadTime: '2021-09-23T15:00:00.000Z',
-			buyId: 2,
-			refundStatus: '미승인',
+			id: 2,
+			refundStatus: 'REJECTED',
 		},
 		{
 			refund: '1000',
 			uploadTime: '2021-09-23T15:00:00.000Z',
-			buyId: 3,
-			refundStatus: '출금',
+			id: 3,
+			refundStatus: 'WITHDRAWN',
 		},
 	],
 };
@@ -34,18 +34,18 @@ export const mockPastPointHistory: MockPointHistory = {
 		{
 			refund: '1000',
 			uploadTime: '2021-09-23T15:00:00.000Z',
-			buyId: 4,
-			refundStatus: '승인',
+			id: 4,
+			refundStatus: 'COMPLETED',
 		},
 		{
 			uploadTime: '2021-09-23T15:00:00.000Z',
-			buyId: 5,
-			refundStatus: '미승인',
+			id: 5,
+			refundStatus: 'REJECTED',
 		},
 		{
 			uploadTime: '2021-09-23T15:00:00.000Z',
-			buyId: 6,
-			refundStatus: '진행중',
+			id: 6,
+			refundStatus: 'IN_PROGRESS',
 		},
 	],
 };

--- a/src/mocks/pointList.ts
+++ b/src/mocks/pointList.ts
@@ -2,12 +2,12 @@ import { Point, PointHistoryList } from '@models/point/entity/point';
 
 type MockPointHistory = {
 	totalPoint: Point;
-	pointList: PointHistoryList;
+	buyResponses: PointHistoryList;
 };
 
 export const mockCurrentPointHistory: MockPointHistory = {
 	totalPoint: '1000',
-	pointList: [
+	buyResponses: [
 		{
 			refund: '1000',
 			uploadTime: '2021-09-23T15:00:00.000Z',
@@ -30,7 +30,7 @@ export const mockCurrentPointHistory: MockPointHistory = {
 
 export const mockPastPointHistory: MockPointHistory = {
 	totalPoint: '1000',
-	pointList: [
+	buyResponses: [
 		{
 			refund: '1000',
 			uploadTime: '2021-09-23T15:00:00.000Z',

--- a/src/mocks/product.ts
+++ b/src/mocks/product.ts
@@ -6,7 +6,7 @@ export const mockProductDetailData: ProductDetail = {
 		'바토 볼레로 스퀘어넥 겨울 루즈핏 니트 (4color) 연말룩/데이트룩/하객룩',
 	price: 19000,
 	refund: 3000,
-	categoryType: 'lotion',
+	categoryType: 'TOPS',
 	thumbnailUrl:
 		'https://cf.product-image.s.zigzag.kr/original/d/2024/1/15/25938_202401151106570706_92971.jpeg',
 	imageUrls: [

--- a/src/mocks/tags.ts
+++ b/src/mocks/tags.ts
@@ -1,10 +1,10 @@
-type tagsType = 'APPROVED' | 'PROGRESS' | 'NOT_APPROVED';
+import { RefundStatus } from '@type/refundStatus';
 
-export const tags: tagsType[] = [
-	'APPROVED',
-	'PROGRESS',
-	'APPROVED',
-	'NOT_APPROVED',
-	'PROGRESS',
-	'NOT_APPROVED',
+export const tags: RefundStatus[] = [
+	'COMPLETED',
+	'IN_PROGRESS',
+	'COMPLETED',
+	'REJECTED',
+	'IN_PROGRESS',
+	'REJECTED',
 ];

--- a/src/models/auth/response/userInfoResponseDTO.ts
+++ b/src/models/auth/response/userInfoResponseDTO.ts
@@ -1,3 +1,5 @@
+import { MemberStatus, Provider } from '@type/userInfo';
+
 export type userInfoResponseDTO = {
 	id: number;
 	name: string;
@@ -5,7 +7,6 @@ export type userInfoResponseDTO = {
 	point: number;
 	account: string;
 	accountBank: string;
-	//TODO memberStatus 타입 모두 작성
-	memberStatus: 'ACTIVE';
-	provider: 'KAKAO' | 'APPLE';
+	memberStatus: MemberStatus;
+	provider: Provider;
 };

--- a/src/models/imageUpload/response/imageUploadSimpleListDTO.ts
+++ b/src/models/imageUpload/response/imageUploadSimpleListDTO.ts
@@ -1,0 +1,5 @@
+import { PointHistory } from '@models/point/entity/point';
+
+export type ImageUploadSimpleListDTO = PointHistory & {
+	certImageUrl: string;
+};

--- a/src/models/imageUpload/response/imageUploadSimpleListDTO.ts
+++ b/src/models/imageUpload/response/imageUploadSimpleListDTO.ts
@@ -1,5 +1,7 @@
 import { PointHistory } from '@models/point/entity/point';
 
-export type ImageUploadSimpleListDTO = PointHistory & {
+type ImageUploadSimpleItem = PointHistory & {
 	certImageUrl: string;
 };
+
+export type ImageUploadSimpleListDTO = ImageUploadSimpleItem[];

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -1,11 +1,12 @@
+import { RefundStatus } from '@type/refundStatus';
+
 export type Point = string;
-export type MockRefundStatus = '진행중' | '미승인' | '승인' | '출금';
 
 export type PointHistory = {
+	id: number;
 	refund?: Point;
 	uploadTime: string;
-	buyId: number;
-	refundStatus: MockRefundStatus;
+	refundStatus: RefundStatus;
 };
 
 export type PointHistoryList = PointHistory[];

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -1,11 +1,11 @@
 export type Point = string;
-export type RefundStatus = '진행중' | '미승인' | '승인' | '출금';
+export type MockRefundStatus = '진행중' | '미승인' | '승인' | '출금';
 
 export type PointHistory = {
 	refund?: Point;
 	uploadTime: string;
 	buyId: number;
-	refundStatus: RefundStatus;
+	refundStatus: MockRefundStatus;
 };
 
 export type PointHistoryList = PointHistory[];

--- a/src/models/point/response/currentPointResponseDTO.ts
+++ b/src/models/point/response/currentPointResponseDTO.ts
@@ -1,0 +1,1 @@
+export type CurrentPointResponseDTO = number;

--- a/src/models/point/response/pointHistoryResponseDTO.ts
+++ b/src/models/point/response/pointHistoryResponseDTO.ts
@@ -1,0 +1,9 @@
+export type PointHistoryResponseDTO = {
+	id: number;
+	redirectUrl: string;
+	uploadTime: string;
+	refund: number;
+	refundStatus: 'UNDER_EXAMINATION';
+	rejectReason: 'string';
+	certImageUrl: 'string';
+};

--- a/src/models/point/response/pointHistoryResponseDTO.ts
+++ b/src/models/point/response/pointHistoryResponseDTO.ts
@@ -1,7 +1,6 @@
 import { PointHistory } from '@models/point/entity/point';
 
 export type PointHistoryResponseDTO = {
-	//TODO 서버 네이밍 매핑하기
 	totalPoint: number;
-	pointList: PointHistory[];
+	buyResponses: PointHistory[];
 };

--- a/src/models/point/response/pointHistoryResponseDTO.ts
+++ b/src/models/point/response/pointHistoryResponseDTO.ts
@@ -1,6 +1,6 @@
-import { PointHistory } from '@models/point/entity/point';
+import { PointHistoryList } from '@models/point/entity/point';
 
 export type PointHistoryResponseDTO = {
 	totalPoint: number;
-	buyResponses: PointHistory[];
+	buyResponses: PointHistoryList;
 };

--- a/src/models/point/response/pointHistoryResponseDTO.ts
+++ b/src/models/point/response/pointHistoryResponseDTO.ts
@@ -1,9 +1,7 @@
+import { PointHistory } from '@models/point/entity/point';
+
 export type PointHistoryResponseDTO = {
-	id: number;
-	redirectUrl: string;
-	uploadTime: string;
-	refund: number;
-	refundStatus: 'UNDER_EXAMINATION';
-	rejectReason: 'string';
-	certImageUrl: 'string';
+	//TODO 서버 네이밍 매핑하기
+	totalPoint: number;
+	pointList: PointHistory[];
 };

--- a/src/models/product/response/productSimpleListResponseDTO.ts
+++ b/src/models/product/response/productSimpleListResponseDTO.ts
@@ -8,10 +8,8 @@ type ProductSimpleResponse = {
 	categoryType: CategoryName;
 	price: number;
 	refund: number;
-	// rating: number; // 지우기로 했는데...
 	thumbnailUrl: string;
 	isDib: boolean;
-	// TODO isLast 추가
 };
 
 export type ProductSimpleListResponseDTO = {

--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -12,7 +12,7 @@ type CategoryParams = {
 };
 
 const Category = () => {
-	const { categoryName = 'lotion' } = useParams<CategoryParams>();
+	const { categoryName = 'TOPS' } = useParams<CategoryParams>();
 	const { id: iconId, name } = categoryList[categoryName];
 
 	const { data } = useGetProductSimpleList(categoryName);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,25 +6,25 @@ import {
 	RecommendationProductCardList,
 	ProductCardList,
 } from '@components/organisms';
+import { useGetUserInfo } from '@hooks/apis/auth';
 import { useGetProductSimpleList } from '@hooks/apis/product';
 import PageLayout from '@layouts/PageLayout';
 import { setAccessToken, setRefreshToken } from '@utils/localStorage/token';
 import { useSearchParams } from 'react-router-dom';
 
 const Home = () => {
-	const { data } = useGetProductSimpleList();
+	const { data: productSimpleList } = useGetProductSimpleList();
+	const { mutate } = useGetUserInfo();
 
-	//TODO params access/refresh token 받아오기
 	const [searchParams] = useSearchParams();
 	const accessTokenParam = searchParams.get('access-token');
 	const refreshTokenParam = searchParams.get('refresh-token');
 
 	useEffect(() => {
-		if (accessTokenParam) {
+		if (accessTokenParam && refreshTokenParam) {
 			setAccessToken(accessTokenParam);
-		}
-		if (refreshTokenParam) {
 			setRefreshToken(refreshTokenParam);
+			mutate();
 		}
 	}, []);
 
@@ -40,7 +40,7 @@ const Home = () => {
 			<div className="px-3 my-3 relative">
 				<ProductCardList
 					type="heart"
-					productList={data?.pages[0].data.itemResponses}
+					productList={productSimpleList?.pages[0].data.itemResponses}
 				/>
 			</div>
 		</PageLayout>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { SearchTextField } from '@components/atoms';
 import { CategoryButtonList } from '@components/molecules';
 import {
@@ -6,11 +8,25 @@ import {
 } from '@components/organisms';
 import { useGetProductSimpleList } from '@hooks/apis/product';
 import PageLayout from '@layouts/PageLayout';
+import { setAccessToken, setRefreshToken } from '@utils/localStorage/token';
+import { useSearchParams } from 'react-router-dom';
 
 const Home = () => {
 	const { data } = useGetProductSimpleList();
 
 	//TODO params access/refresh token 받아오기
+	const [searchParams] = useSearchParams();
+	const accessTokenParam = searchParams.get('access-token');
+	const refreshTokenParam = searchParams.get('refresh-token');
+
+	useEffect(() => {
+		if (accessTokenParam) {
+			setAccessToken(accessTokenParam);
+		}
+		if (refreshTokenParam) {
+			setRefreshToken(refreshTokenParam);
+		}
+	}, []);
 
 	return (
 		<PageLayout leftType="logo" className="flex flex-col">

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -1,11 +1,14 @@
 import { ImageUploadButton } from '@components/atoms';
 import { ImageContainer } from '@components/molecules';
+import { useGetImageUploadSimpleList } from '@hooks/apis/imageUpload';
 import PageLayout from '@layouts/PageLayout';
-import { uploadImages } from '@mocks/uploadImages';
+//import { uploadImages } from '@mocks/uploadImages';
 import { useNavigate } from 'react-router-dom';
 
 const ImageUpload = () => {
 	const navigate = useNavigate();
+
+	const { data } = useGetImageUploadSimpleList();
 
 	const handleClick = (imageId: number) => {
 		navigate(`/image-upload/${imageId}`);
@@ -31,11 +34,11 @@ const ImageUpload = () => {
 			</p>
 			<div className="grid grid-cols-3 gap-[11px]">
 				<ImageUploadButton />
-				{uploadImages.map((image, idx) => (
+				{data.map((item, idx) => (
 					<ImageContainer
 						key={`imageContainer${idx}`}
-						imageUrl={image.image}
-						status={image.tag}
+						imageUrl={item.certImageUrl}
+						status={item.refundStatus}
 						onClick={() => handleClick(10)}
 					/>
 				))}

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -12,24 +12,24 @@ import {
 } from '@components/molecules';
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
-import { Status } from '@type/status';
+import { RefundStatus } from '@type/refundStatus';
 import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
 
 type StatusValueType = {
-	[K in Status]: ReactNode;
+	[K in RefundStatus]: ReactNode;
 };
 
 const ImageUploadDetail = () => {
 	//Todo: api 응답 정보로 교체
 	const date = '2023-12-12T12:12:12:32';
-	const status: Status = 'APPROVED';
+	const status: RefundStatus = 'COMPLETED';
 	const point = '2000';
 	const approvedMessage = '어떠어떠어떠한 이유로 승인되지 않았습니다.';
 
 	const statusValue: StatusValueType = {
-		APPROVED: <ApprovedTag size="large" />,
-		NOT_APPROVED: <NotApprovedTag size="large" />,
-		PROGRESS: <ProgressTag size="large" />,
+		COMPLETED: <ApprovedTag size="large" />,
+		REJECTED: <NotApprovedTag size="large" />,
+		IN_PROGRESS: <ProgressTag size="large" />,
 	};
 
 	const renderTextValue = (text: string, typography: string) => (
@@ -37,14 +37,14 @@ const ImageUploadDetail = () => {
 	);
 
 	const renderExtraContents = () => {
-		if (status === 'APPROVED') {
+		if (status === 'COMPLETED') {
 			return (
 				<DefaultKeyValueContainer
 					title="승인 금액"
 					value={getPointText(point)}
 				/>
 			);
-		} else if (status === 'NOT_APPROVED') {
+		} else if (status === 'REJECTED') {
 			const textValue = renderTextValue(
 				approvedMessage,
 				'typography-Body2 typography-R',

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -15,8 +15,13 @@ import { mockImages } from '@mocks/images';
 import { RefundStatus } from '@type/refundStatus';
 import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
 
+type ImageUploadDetailRefundStatus = Extract<
+	RefundStatus,
+	'IN_PROGRESS' | 'COMPLETED' | 'REJECTED'
+>;
+
 type StatusValueType = {
-	[K in RefundStatus]: ReactNode;
+	[K in ImageUploadDetailRefundStatus]: ReactNode;
 };
 
 const ImageUploadDetail = () => {

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -6,10 +6,7 @@ import {
 	NotApprovedTag,
 	ProgressTag,
 } from '@components/atoms';
-import {
-	DefaultKeyValueContainer,
-	SmallProductDetailImageSlider,
-} from '@components/molecules';
+import { DefaultKeyValueContainer } from '@components/molecules';
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
 import { RefundStatus } from '@type/refundStatus';
@@ -65,7 +62,7 @@ const ImageUploadDetail = () => {
 
 	return (
 		<PageLayout leftType="back">
-			<SmallProductDetailImageSlider images={mockImages} />
+			<img src={mockImages[0]} alt="인증 사진" />
 			<div className="p-6 flex flex-col gap-6">
 				<DefaultKeyValueContainer
 					title="업로드 일시"

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -10,10 +10,9 @@ import { getProvider, getUserName } from '@utils/localStorage/userInfo';
 import { useNavigate } from 'react-router-dom';
 
 const MyPage = () => {
-	//const { data } = useGetUserInfo();
-
 	const [userName, setUserName] = useState('홍길동');
 	const [provider, setProvider] = useState('카카오톡');
+
 	useEffect(() => {
 		const userName = getUserName();
 		const provider = getProvider();

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import notificationImg from '@assets/images/notification.png';
 import { ProgressBar } from '@components/index';
 import ClearLayout from '@layouts/ClearLayout';
+import { useProductStore } from '@stores/productStore';
 
 const Notification = () => {
 	const [state, setState] = useState({
@@ -21,10 +22,11 @@ const Notification = () => {
 		return () => clearTimeout(timeoutId);
 	}, []);
 
+	const redirectUrl = useProductStore(state => state.redirectUrl);
+
 	useEffect(() => {
 		if (!state.isAnimating) {
-			//TODO: 서버로 부터 받은 url 정보로 변경
-			window.location.replace('https://zigzag.kr/');
+			window.location.replace(redirectUrl);
 		}
 	}, [state]);
 

--- a/src/pages/Point.tsx
+++ b/src/pages/Point.tsx
@@ -1,6 +1,9 @@
 import { CaptionButton } from '@components/atoms';
 import { PointHeader } from '@components/molecules';
-import { CurrentPointHistory, PastPointHistory } from '@components/organisms';
+import {
+	ExpectedPointHistory,
+	CumulatedPointHistory,
+} from '@components/organisms';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
 import PageLayout from '@layouts/PageLayout';
 import { useNavigate } from 'react-router-dom';
@@ -18,8 +21,8 @@ const Point = () => {
 		<PageLayout leftType="home" className="px-6 py-3">
 			<PointHeader />
 			<div className="flex flex-col gap-[14px] mb-5">
-				<CurrentPointHistory />
-				<PastPointHistory />
+				<ExpectedPointHistory />
+				<CumulatedPointHistory />
 			</div>
 			<FixedBottomLayout childrenPadding="px-[20px]" height="h-15">
 				<CaptionButton

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { BuyWithLikeButton, CardInfo } from '@components/atoms';
 import { SmallProductDetailImageSlider } from '@components/molecules';
@@ -7,6 +7,7 @@ import { useGetProductDetailList } from '@hooks/apis/product';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
 import PageLayout from '@layouts/PageLayout';
 // import { mockProductDetailData } from '@mocks/product';
+import { useProductStore } from '@stores/productStore';
 import { getYoutubeIdFromUrl } from '@utils/formatData';
 import { useParams } from 'react-router-dom';
 import YouTube from 'react-youtube';
@@ -19,6 +20,12 @@ const ProductDetail = () => {
 
 	const { imageUrls, title, price, refund, videoUrls, redirectUrl, isDib } =
 		productDetail;
+
+	const setRedirectUrl = useProductStore(state => state.setRedirectUrl);
+
+	useEffect(() => {
+		setRedirectUrl(redirectUrl);
+	}, [redirectUrl]);
 
 	const [isDetailImageSliderOpen, setIsDetailImageSliderOpen] = useState(false);
 
@@ -82,10 +89,6 @@ const ProductDetail = () => {
 						{textWithEnter.moreDescription}
 					</h6>
 					<iframe
-						//src={"https://zigzag.kr/catalog/products/127482963"}
-						//src={"https://s.zigzag.kr/f2KRWpFiXx?tab=review"}
-						//src={"https://zigzag.kr/p/129629101?airbridge_referrer=airbridge%3Dtrue%26event_uuid%3D47b4ac24-c9aa-4c86-ab80-ecc332b39550%26client_id%3Dbdb7987c-7f89-414a-b8a8-f9746d7bb5e1%26referrer_timestamp%3D1707217989839%26channel%3Dsharelink%26campaign%3Dproduct%26ad_group%3Dnormal%26tab%3Dreview&utm_source=sharelink&utm_campaign=product&channel=sharelink&campaign=product&ad_group=normal&deeplink_url=zigzag%3A%2F%2F%2Fproduct_detail%3Fbrowsing_type%3DINTERNAL_BROWSER%26catalog_product_id%3D129629101%26url%3Dhttps%3A%2F%2Fstore.zigzag.kr%2Fapp%2Fcatalog%2Fproducts%2F129629101%3Fbrowsing_type%26shop_id%3D12897%26shop_product_no%3D%26uau%3D1b7555c0-fe6f-43f6-bd39-403fb6be7d61%26catalog_product_id%3D129629101&fallback_desktop=https%3A%2F%2Fzigzag.kr%2Fp%2F129629101&tab=review"}
-						//src={"https://zigzag.kr/catalog/products/127482963?tab=review"}
 						src={redirectUrl}
 						className="w-full aspect-[1/2] border-Gray60 rounded-3xl border-[7px]"
 					/>

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -59,19 +59,21 @@ const ProductDetail = () => {
 					size="large"
 					category="의류"
 				/>
-				<div className="w-full relative flex flex-col gap-[10px]">
-					<h3 className="text-White typography-Body2 typography-SB">
-						❣️ 유저들의 달달한 리뷰 확인하기
-					</h3>
-					<YouTube
-						videoId={getYoutubeIdFromUrl(videoUrls)}
-						opts={{
-							height: '100%',
-							width: '100%',
-						}}
-						className="h-full aspect-video"
-					/>
-				</div>
+				{videoUrls.length > 0 && (
+					<div className="w-full relative flex flex-col gap-[10px]">
+						<h3 className="text-White typography-Body2 typography-SB">
+							❣️ 유저들의 달달한 리뷰 확인하기
+						</h3>
+						<YouTube
+							videoId={getYoutubeIdFromUrl(videoUrls)}
+							opts={{
+								height: '100%',
+								width: '100%',
+							}}
+							className="h-full aspect-video"
+						/>
+					</div>
+				)}
 				<div className="whitespace-pre-line">
 					<h3 className="text-White typography-Body2 typography-SB">
 						{textWithEnter.moreTitle}
@@ -83,6 +85,7 @@ const ProductDetail = () => {
 						//src={"https://zigzag.kr/catalog/products/127482963"}
 						//src={"https://s.zigzag.kr/f2KRWpFiXx?tab=review"}
 						//src={"https://zigzag.kr/p/129629101?airbridge_referrer=airbridge%3Dtrue%26event_uuid%3D47b4ac24-c9aa-4c86-ab80-ecc332b39550%26client_id%3Dbdb7987c-7f89-414a-b8a8-f9746d7bb5e1%26referrer_timestamp%3D1707217989839%26channel%3Dsharelink%26campaign%3Dproduct%26ad_group%3Dnormal%26tab%3Dreview&utm_source=sharelink&utm_campaign=product&channel=sharelink&campaign=product&ad_group=normal&deeplink_url=zigzag%3A%2F%2F%2Fproduct_detail%3Fbrowsing_type%3DINTERNAL_BROWSER%26catalog_product_id%3D129629101%26url%3Dhttps%3A%2F%2Fstore.zigzag.kr%2Fapp%2Fcatalog%2Fproducts%2F129629101%3Fbrowsing_type%26shop_id%3D12897%26shop_product_no%3D%26uau%3D1b7555c0-fe6f-43f6-bd39-403fb6be7d61%26catalog_product_id%3D129629101&fallback_desktop=https%3A%2F%2Fzigzag.kr%2Fp%2F129629101&tab=review"}
+						//src={"https://zigzag.kr/catalog/products/127482963?tab=review"}
 						src={redirectUrl}
 						className="w-full aspect-[1/2] border-Gray60 rounded-3xl border-[7px]"
 					/>

--- a/src/stores/productStore.tsx
+++ b/src/stores/productStore.tsx
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+type ProductStore = {
+	redirectUrl: string;
+	setRedirectUrl: (redirectUrl: string) => void;
+};
+
+export const useProductStore = create(
+	persist<ProductStore>(
+		set => ({
+			redirectUrl: '',
+			setRedirectUrl: (redirectUrl: string) => {
+				set({ redirectUrl });
+			},
+		}),
+		{
+			name: 'product',
+			storage: createJSONStorage(() => localStorage),
+		},
+	),
+);

--- a/src/stories/atoms/ListPoint.stories.tsx
+++ b/src/stories/atoms/ListPoint.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
 	args: {
 		uploadTime: '2023.12.23',
 		refund: '200',
-		buyId: 4,
-		refundStatus: '승인',
+		id: 4,
+		refundStatus: 'COMPLETED',
 	},
 };

--- a/src/stories/molecules/ImageContainer.stories.tsx
+++ b/src/stories/molecules/ImageContainer.stories.tsx
@@ -26,20 +26,20 @@ type Story = StoryObj<typeof meta>;
 export const Approved: Story = {
 	args: {
 		imageUrl: 'https://via.placeholder.com/2560x1440',
-		status: 'APPROVED',
+		status: 'COMPLETED',
 	},
 };
 
 export const Progress: Story = {
 	args: {
 		imageUrl: 'https://via.placeholder.com/2560x1440',
-		status: 'PROGRESS',
+		status: 'IN_PROGRESS',
 	},
 };
 
 export const Not_Approved: Story = {
 	args: {
 		imageUrl: 'https://via.placeholder.com/2560x1440',
-		status: 'NOT_APPROVED',
+		status: 'REJECTED',
 	},
 };

--- a/src/type/refundStatus.ts
+++ b/src/type/refundStatus.ts
@@ -1,1 +1,7 @@
-export type RefundStatus = 'IN_PROGRESS' | 'COMPLETED' | 'REJECTED';
+export type RefundStatus =
+	| 'IN_PROGRESS'
+	| 'COMPLETED'
+	| 'REJECTED'
+	| 'WITHDRAWN';
+
+export type KoRefundStatus = '미승인' | '승인' | '진행중' | '출금';

--- a/src/type/refundStatus.ts
+++ b/src/type/refundStatus.ts
@@ -1,0 +1,1 @@
+export type RefundStatus = 'IN_PROGRESS' | 'COMPLETED' | 'REJECTED';

--- a/src/type/status.ts
+++ b/src/type/status.ts
@@ -1,2 +1,0 @@
-//Todo: 서버에서 받는 값을 key로 교체
-export type Status = 'APPROVED' | 'PROGRESS' | 'NOT_APPROVED';

--- a/src/type/userInfo.ts
+++ b/src/type/userInfo.ts
@@ -1,0 +1,2 @@
+export type MemberStatus = 'ACTIVE' | 'INACTIVE';
+export type Provider = 'KAKAO' | 'APPLE';

--- a/src/utils/localStorage/token.ts
+++ b/src/utils/localStorage/token.ts
@@ -3,19 +3,13 @@ import LocalStorageKey from '@constants/localStorageKey';
 export const getAccessToken = () =>
 	localStorage.getItem(LocalStorageKey.ACCESS_TOKEN);
 export const setAccessToken = (accessToken: string) =>
-	localStorage.setItem(
-		LocalStorageKey.ACCESS_TOKEN,
-		JSON.stringify(accessToken),
-	);
+	localStorage.setItem(LocalStorageKey.ACCESS_TOKEN, accessToken);
 export const removeAccessToken = () =>
 	localStorage.removeItem(LocalStorageKey.ACCESS_TOKEN);
 
 export const getRefreshToken = () =>
 	localStorage.getItem(LocalStorageKey.REFRESH_TOKEN);
 export const setRefreshToken = (refreshToken: string) =>
-	localStorage.setItem(
-		LocalStorageKey.REFRESH_TOKEN,
-		JSON.stringify(refreshToken),
-	);
+	localStorage.setItem(LocalStorageKey.REFRESH_TOKEN, refreshToken);
 export const removeRefreshToken = () =>
 	localStorage.removeItem(LocalStorageKey.REFRESH_TOKEN);


### PR DESCRIPTION
### **요약 (Summary)**
포인트 및 인증 api를 연동합니다.


### **목표 (Goals)**
- 포인트 페이지 api 모두 연동
- 로그인 인증 수정 완료
- 아이템 카테고리 수정 완료
- 인증 전체 페이지 api 연동

### **목표가 아닌 것 (Non-Goals)**
PR이 더 커지기 전에..! 날려야 할 것 같아서 다음 태스크는 다음 PR로 미루었습니다
- 포인트 상세페이지 api 연동
- 추천 상품용 api 연동

### **계획 (Plan)**
사용자 정보 [name, provider]의 경우는 한번 받아오면 바뀔일이 전혀 없을 것 같아서, 로그인 성공 시 api를 요청하여 받아와 localStorage에 저장하고 쓰는 방식으로 구현하였습니다.
