### PR TITLE
Feat#229.포인트 상세 및 추천상품 api 연동

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,14 +1,8 @@
 import { LogoutRequestDTO } from '@models/auth/request/logoutRequestDTO';
-import { TokenResponseDTO } from '@models/auth/response/tokenResponseDTO';
 import { userInfoResponseDTO } from '@models/auth/response/userInfoResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 import { api } from '.';
-
-export const kakaoLogin = async (): Promise<ApiResponse<TokenResponseDTO>> => {
-	const response = await api.get('/oauth2/authorization/kakao');
-	return response.data;
-};
 
 export const logout = async (
 	request: LogoutRequestDTO,

--- a/src/apis/imageUpload.ts
+++ b/src/apis/imageUpload.ts
@@ -1,4 +1,4 @@
-import { ImageUploadSimpleListDTO } from '@models/imageUpload/response/ImageUploadSimpleListDTO';
+import { ImageUploadSimpleListDTO } from '@models/imageUpload/response/imageUploadSimpleListDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 import { api } from '.';

--- a/src/apis/imageUpload.ts
+++ b/src/apis/imageUpload.ts
@@ -1,11 +1,19 @@
-import { ImageUploadSimpleListDTO } from '@models/imageUpload/response/imageUploadSimpleListDTO';
+import { ImageUploadDetailListResponseDTO } from '@models/imageUpload/response/imageUploadDetailListResponseDTO';
+import { ImageUploadSimpleListResponseDTO } from '@models/imageUpload/response/imageUploadSimpleListResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 import { api } from '.';
 
 export const getImageUploadSimpleList = async (): Promise<
-	ApiResponse<ImageUploadSimpleListDTO>
+	ApiResponse<ImageUploadSimpleListResponseDTO>
 > => {
 	const response = await api.get('/api/v1/buys/me');
+	return response.data;
+};
+
+export const getImageUploadDetailList = async (
+	buyId: number,
+): Promise<ApiResponse<ImageUploadDetailListResponseDTO>> => {
+	const response = await api.get(`/api/v1/buys/${buyId}`);
 	return response.data;
 };

--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -1,6 +1,7 @@
 import { CategoryName } from '@constants/categoryList';
 import { ProductDetailListResponseDTO } from '@models/product/response/productDetailListResponseDTO';
 import { ProductSimpleListResponseDTO } from '@models/product/response/productSimpleListResponseDTO';
+import { RecommendedProductSimpleListResposneDTO } from '@models/product/response/recommendedProductSimpleListResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
 import { api } from '.';
@@ -14,6 +15,13 @@ export const getProductSimpleList = async (
 		itemCategoryType,
 	};
 	const response = await api.get('/api/v1/items', { params });
+	return response.data;
+};
+
+export const getRecommendedProductSimpleList = async (): Promise<
+	ApiResponse<RecommendedProductSimpleListResposneDTO>
+> => {
+	const response = await api.get('/api/v1/items/suggested');
 	return response.data;
 };
 

--- a/src/components/atoms/ImageUploadButton.tsx
+++ b/src/components/atoms/ImageUploadButton.tsx
@@ -13,7 +13,7 @@ const ImageUploadButton = () => {
 				return;
 			}
 			const formData = new FormData();
-			formData.append('image', e.target.files[0]);
+			formData.append('file', e.target.files[0]);
 			//TODO api 연동 + invalidate getImageUploadSimpleList
 		},
 		[],

--- a/src/components/atoms/ImageUploadButton.tsx
+++ b/src/components/atoms/ImageUploadButton.tsx
@@ -1,19 +1,47 @@
 import { Button } from 'konsta/react';
+import { useCallback, useRef } from 'react';
 
 import { SvgIcon } from '@components/common';
 import colors from '@constants/colors';
 
 const ImageUploadButton = () => {
-	const handleClick = () => {
-		console.log('갤러리/폴더 열기');
-	};
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const onUploadImage = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			if (!e.target.files) {
+				return;
+			}
+			const formData = new FormData();
+			formData.append('image', e.target.files[0]);
+			//TODO api 연동 + invalidate getImageUploadSimpleList
+		},
+		[],
+	);
+
+	const handleClick = useCallback(() => {
+		if (!inputRef.current) {
+			return;
+		}
+		inputRef.current.click();
+	}, []);
+
 	return (
-		<Button
-			className="k-color-Gray80 rounded-[5px] h-full !relative flex items-center justify-center aspect-square active:opacity-30"
-			onClick={handleClick}
-		>
-			<SvgIcon id="plus" size={32} color={colors.Gray50} />
-		</Button>
+		<>
+			<input
+				type="file"
+				accept="image/*"
+				ref={inputRef}
+				onChange={onUploadImage}
+				className="hidden"
+			/>
+			<Button
+				className="k-color-Gray80 rounded-[5px] h-full !relative flex items-center justify-center aspect-square active:opacity-30"
+				onClick={handleClick}
+			>
+				<SvgIcon id="plus" size={32} color={colors.Gray50} />
+			</Button>
+		</>
 	);
 };
 

--- a/src/components/common/Routing.tsx
+++ b/src/components/common/Routing.tsx
@@ -35,7 +35,7 @@ const Routing = () => {
 			<Route path="/my-page" element={<MyPage />} />
 			<Route path="/point" element={<Point />} />
 			<Route path="/image-upload" element={<ImageUpload />} />
-			<Route path="/image-upload/:imageId" element={<ImageUploadDetail />} />
+			<Route path="/image-upload/:buyId" element={<ImageUploadDetail />} />
 			<Route path="/withdrawal/*" element={<Withdrawal />}>
 				<Route path="pre" element={<PreWithdrawal />} />
 				<Route path="progress" element={<ProgressWithdrawal />} />

--- a/src/components/organisms/RecommendationProductCardList.tsx
+++ b/src/components/organisms/RecommendationProductCardList.tsx
@@ -1,12 +1,8 @@
 import { ProductCardList } from '@components/organisms';
-import { mockProductSimpleList } from '@mocks/mockProductSimpleList';
-//import { useGetProductSimpleList } from '@hooks/apis/product';
+import { useGetRecommendedProductSimpleList } from '@hooks/apis/product';
 
 const RecommendationProductCardList = () => {
-	// TODO: 추천상품 API 연동
-	//const { data } = useGetProductSimpleList();
-
-	const productList = mockProductSimpleList.slice(0, 3);
+	const { data } = useGetRecommendedProductSimpleList();
 
 	return (
 		<div className="flex flex-col gap-3">
@@ -17,7 +13,7 @@ const RecommendationProductCardList = () => {
 				gridCols={3}
 				type="heart"
 				size="small"
-				productList={productList}
+				productList={data}
 			/>
 		</div>
 	);

--- a/src/constants/koRefundStatus.tsx
+++ b/src/constants/koRefundStatus.tsx
@@ -2,7 +2,7 @@ const koRefundStatus = {
 	IN_PROGRESS: '진행중',
 	COMPLETED: '승인',
 	REJECTED: '미승인',
-	WITHDRAWN: '출금',
+	WITHDRAWN_COMPLETED: '출금',
 } as const;
 
 export default koRefundStatus;

--- a/src/hooks/apis/auth.ts
+++ b/src/hooks/apis/auth.ts
@@ -1,13 +1,9 @@
-import { getUserInfo, kakaoLogin, logout } from '@apis/auth';
+import { getUserInfo, logout } from '@apis/auth';
 import { LogoutRequestDTO } from '@models/auth/request/logoutRequestDTO';
-import { TokenResponseDTO } from '@models/auth/response/tokenResponseDTO';
 import { useMutation } from '@tanstack/react-query';
-import { ApiResponse } from '@type/apiResponse';
 import {
 	removeAccessToken,
 	removeRefreshToken,
-	setAccessToken,
-	setRefreshToken,
 } from '@utils/localStorage/token';
 import {
 	removeProvider,
@@ -15,21 +11,6 @@ import {
 	setProvider,
 	setUserName,
 } from '@utils/localStorage/userInfo';
-
-export const useKakaoLogin = (errorCallback?: (error: Error) => void) => {
-	return useMutation({
-		mutationFn: () => kakaoLogin(),
-		onSuccess: async (data: ApiResponse<TokenResponseDTO>) => {
-			setAccessToken(data.data.accessToken);
-			setRefreshToken(data.data.refreshToken);
-
-			const userInfoData = await getUserInfo();
-			setUserName(userInfoData.data.name);
-			setProvider(userInfoData.data.provider === 'KAKAO' ? '카카오톡' : '애플');
-		},
-		onError: errorCallback,
-	});
-};
 
 export const useLogout = (
 	successCallback: () => void,

--- a/src/hooks/apis/imageUpload.ts
+++ b/src/hooks/apis/imageUpload.ts
@@ -1,10 +1,21 @@
-import { getImageUploadSimpleList } from '@apis/imageUpload';
+import {
+	getImageUploadDetailList,
+	getImageUploadSimpleList,
+} from '@apis/imageUpload';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetImageUploadSimpleList = () => {
 	return useSuspenseQuery({
 		queryKey: ['imageUploadSimpleList'],
 		queryFn: () => getImageUploadSimpleList(),
+		select: data => data.data,
+	});
+};
+
+export const useGetImageUploadDetailList = (buyId: number) => {
+	return useSuspenseQuery({
+		queryKey: ['imageUploadDetailList'],
+		queryFn: () => getImageUploadDetailList(buyId),
 		select: data => data.data,
 	});
 };

--- a/src/hooks/apis/product.ts
+++ b/src/hooks/apis/product.ts
@@ -1,4 +1,8 @@
-import { getProductDetailList, getProductSimpleList } from '@apis/product';
+import {
+	getProductDetailList,
+	getProductSimpleList,
+	getRecommendedProductSimpleList,
+} from '@apis/product';
 import { CategoryName } from '@constants/categoryList';
 import { useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 
@@ -12,6 +16,14 @@ export const useGetProductSimpleList = (itemCategoryType?: CategoryName) => {
 			const nextPage = allPages.length + 1;
 			return lastPage?.data.isLastPage ? undefined : nextPage;
 		},
+	});
+};
+
+export const useGetRecommendedProductSimpleList = () => {
+	return useSuspenseQuery({
+		queryKey: ['recommendedProductSimpleList'],
+		queryFn: () => getRecommendedProductSimpleList(),
+		select: data => data.data,
 	});
 };
 

--- a/src/models/auth/response/tokenResponseDTO.ts
+++ b/src/models/auth/response/tokenResponseDTO.ts
@@ -1,4 +1,0 @@
-export type TokenResponseDTO = {
-	accessToken: string;
-	refreshToken: string;
-};

--- a/src/models/imageUpload/request/imageUploadDetailListRequestDTO.ts
+++ b/src/models/imageUpload/request/imageUploadDetailListRequestDTO.ts
@@ -1,0 +1,3 @@
+export type ImageUploadDetailListRequestDTO = {
+	buyId: number;
+};

--- a/src/models/imageUpload/response/imageUploadDetailListResponseDTO.ts
+++ b/src/models/imageUpload/response/imageUploadDetailListResponseDTO.ts
@@ -1,8 +1,11 @@
 import { PointHistory } from '@models/point/entity/point';
+import { ImageUploadDetailRefundStatus } from '@type/refundStatus';
 
-type ImageUploadDetailItem = PointHistory & {
+export type ImageUploadDetailListResponseDTO = Omit<
+	PointHistory,
+	'refundStatus'
+> & {
+	refundStatus: ImageUploadDetailRefundStatus;
 	rejectReason: string;
 	certImageUrl: string;
 };
-
-export type ImageUploadDetailListResponseDTO = ImageUploadDetailItem[];

--- a/src/models/imageUpload/response/imageUploadDetailListResponseDTO.ts
+++ b/src/models/imageUpload/response/imageUploadDetailListResponseDTO.ts
@@ -1,0 +1,8 @@
+import { PointHistory } from '@models/point/entity/point';
+
+type ImageUploadDetailItem = PointHistory & {
+	rejectReason: string;
+	certImageUrl: string;
+};
+
+export type ImageUploadDetailListResponseDTO = ImageUploadDetailItem[];

--- a/src/models/imageUpload/response/imageUploadSimpleListResponseDTO.ts
+++ b/src/models/imageUpload/response/imageUploadSimpleListResponseDTO.ts
@@ -4,4 +4,4 @@ type ImageUploadSimpleItem = PointHistory & {
 	certImageUrl: string;
 };
 
-export type ImageUploadSimpleListDTO = ImageUploadSimpleItem[];
+export type ImageUploadSimpleListResponseDTO = ImageUploadSimpleItem[];

--- a/src/models/imageUpload/response/imageUploadSimpleListResponseDTO.ts
+++ b/src/models/imageUpload/response/imageUploadSimpleListResponseDTO.ts
@@ -1,6 +1,8 @@
 import { PointHistory } from '@models/point/entity/point';
+import { ImageUploadDetailRefundStatus } from '@type/refundStatus';
 
-type ImageUploadSimpleItem = PointHistory & {
+type ImageUploadSimpleItem = Omit<PointHistory, 'refundStatus'> & {
+	refundStatus: ImageUploadDetailRefundStatus;
 	certImageUrl: string;
 };
 

--- a/src/models/product/response/productSimpleListResponseDTO.ts
+++ b/src/models/product/response/productSimpleListResponseDTO.ts
@@ -1,6 +1,6 @@
 import { CategoryName } from '@constants/categoryList';
 
-type ProductSimpleResponse = {
+export type ProductSimpleResponse = {
 	id: number;
 	title: string;
 	redirectUrl: string;

--- a/src/models/product/response/productSimpleListResponseDTO.ts
+++ b/src/models/product/response/productSimpleListResponseDTO.ts
@@ -3,7 +3,6 @@ import { CategoryName } from '@constants/categoryList';
 type ProductSimpleResponse = {
 	id: number;
 	title: string;
-	detail: string;
 	redirectUrl: string;
 	categoryType: CategoryName;
 	price: number;

--- a/src/models/product/response/recommendedProductSimpleListResponseDTO.ts
+++ b/src/models/product/response/recommendedProductSimpleListResponseDTO.ts
@@ -1,3 +1,3 @@
-import { ProductSimpleList } from '@models/product/entity/product';
+import { ProductSimpleResponse } from './productSimpleListResponseDTO';
 
-export type RecommendedProductSimpleListResposneDTO = ProductSimpleList[];
+export type RecommendedProductSimpleListResposneDTO = ProductSimpleResponse[];

--- a/src/models/product/response/recommendedProductSimpleListResponseDTO.ts
+++ b/src/models/product/response/recommendedProductSimpleListResponseDTO.ts
@@ -1,0 +1,3 @@
+import { ProductSimpleList } from '@models/product/entity/product';
+
+export type RecommendedProductSimpleListResposneDTO = ProductSimpleList[];

--- a/src/pages/ImageUpload.tsx
+++ b/src/pages/ImageUpload.tsx
@@ -34,14 +34,15 @@ const ImageUpload = () => {
 			</p>
 			<div className="grid grid-cols-3 gap-[11px]">
 				<ImageUploadButton />
-				{data.map((item, idx) => (
-					<ImageContainer
-						key={`imageContainer${idx}`}
-						imageUrl={item.certImageUrl}
-						status={item.refundStatus}
-						onClick={() => handleClick(10)}
-					/>
-				))}
+				{data.length > 0 &&
+					data.map((item, idx) => (
+						<ImageContainer
+							key={`imageContainer${idx}`}
+							imageUrl={item.certImageUrl}
+							status={item.refundStatus}
+							onClick={() => handleClick(10)}
+						/>
+					))}
 			</div>
 		</PageLayout>
 	);

--- a/src/pages/ImageUploadDetail.tsx
+++ b/src/pages/ImageUploadDetail.tsx
@@ -7,26 +7,20 @@ import {
 	ProgressTag,
 } from '@components/atoms';
 import { DefaultKeyValueContainer } from '@components/molecules';
+import { useGetImageUploadDetailList } from '@hooks/apis/imageUpload';
 import PageLayout from '@layouts/PageLayout';
 import { mockImages } from '@mocks/images';
-import { RefundStatus } from '@type/refundStatus';
+import { ImageUploadDetailRefundStatus } from '@type/refundStatus';
 import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
-
-type ImageUploadDetailRefundStatus = Extract<
-	RefundStatus,
-	'IN_PROGRESS' | 'COMPLETED' | 'REJECTED'
->;
+import { useParams } from 'react-router-dom';
 
 type StatusValueType = {
 	[K in ImageUploadDetailRefundStatus]: ReactNode;
 };
 
 const ImageUploadDetail = () => {
-	//Todo: api 응답 정보로 교체
-	const date = '2023-12-12T12:12:12:32';
-	const status: RefundStatus = 'COMPLETED';
-	const point = '2000';
-	const approvedMessage = '어떠어떠어떠한 이유로 승인되지 않았습니다.';
+	const { buyId } = useParams();
+	const { data } = useGetImageUploadDetailList(Number(buyId));
 
 	const statusValue: StatusValueType = {
 		COMPLETED: <ApprovedTag size="large" />,
@@ -39,16 +33,16 @@ const ImageUploadDetail = () => {
 	);
 
 	const renderExtraContents = () => {
-		if (status === 'COMPLETED') {
+		if (data.refundStatus === 'COMPLETED') {
 			return (
 				<DefaultKeyValueContainer
 					title="승인 금액"
-					value={getPointText(point)}
+					value={getPointText(data.refund)}
 				/>
 			);
-		} else if (status === 'REJECTED') {
+		} else if (data.refundStatus === 'REJECTED') {
 			const textValue = renderTextValue(
-				approvedMessage,
+				data.rejectReason,
 				'typography-Body2 typography-R',
 			);
 
@@ -66,9 +60,12 @@ const ImageUploadDetail = () => {
 			<div className="p-6 flex flex-col gap-6">
 				<DefaultKeyValueContainer
 					title="업로드 일시"
-					value={getDataInYYYYMMDDSplitedByDot(date)}
+					value={getDataInYYYYMMDDSplitedByDot(data.uploadTime)}
 				/>
-				<KeyValueContainer title="승인 여부" value={statusValue[status]} />
+				<KeyValueContainer
+					title="승인 여부"
+					value={statusValue[data.refundStatus]}
+				/>
 				{renderExtraContents()}
 			</div>
 		</PageLayout>

--- a/src/type/refundStatus.ts
+++ b/src/type/refundStatus.ts
@@ -4,4 +4,9 @@ export type RefundStatus =
 	| 'REJECTED'
 	| 'WITHDRAWN';
 
+export type ImageUploadDetailRefundStatus = Extract<
+	RefundStatus,
+	'IN_PROGRESS' | 'COMPLETED' | 'REJECTED'
+>;
+
 export type KoRefundStatus = '미승인' | '승인' | '진행중' | '출금';

--- a/src/type/refundStatus.ts
+++ b/src/type/refundStatus.ts
@@ -2,7 +2,9 @@ export type RefundStatus =
 	| 'IN_PROGRESS'
 	| 'COMPLETED'
 	| 'REJECTED'
-	| 'WITHDRAWN';
+	// | 'WITHDRAWN_IN_PROGRESS'
+	| 'WITHDRAWN_COMPLETED';
+// | 'WITHDRAWN_REJECTED'
 
 export type ImageUploadDetailRefundStatus = Extract<
 	RefundStatus,


### PR DESCRIPTION
### **요약 (Summary)**
포인트 상세 페이지 및 추천 상품 api를 연동합니다.

### **목표 (Goals)**
- 포인트 상세페이지 (이미지를 올리는 방식이 변경될 것 같아 이미지 올리는 기능이 없어서 포인트 상세 페이지 api 기능 확인은 하지 못하였습니다.)
- 추천 상품 api 연동

### **목표가 아닌 것 (Non-Goals)**
- 이미지 올리는 방식이 itemId가 필요해서 모달 or 포인트 상세페이지에서 올리는 방식으로 변경될 것 같습니다. 따라서 디자인상으로 변경이 이루어질 것 같아 다음 태스크로 미루었습니다.
- 환금 상세 페이지도 서버와 소통 중이고, 환금 승인 진행중/거절에 대한 디자인도 없는 상태라 다음 태스크로 미루었습니다.

### **마일스톤 (Milestones)**
- 다음으로 찜, 계좌 관련 api를 연동하겠습니다.
