### PR TITLE
Feat#231.찜 및 계좌 관련 api 연동

### DIFF
--- a/src/apis/account.ts
+++ b/src/apis/account.ts
@@ -1,0 +1,11 @@
+import { AccountInfoResponseDTO } from '@models/account/response/accountInfoResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+import { api } from '.';
+
+export const getAccountInfo = async (): Promise<
+	ApiResponse<AccountInfoResponseDTO>
+> => {
+	const response = await api.get('/api/v1/members/me/account');
+	return response.data;
+};

--- a/src/apis/account.ts
+++ b/src/apis/account.ts
@@ -9,3 +9,8 @@ export const getAccountInfo = async (): Promise<
 	const response = await api.get('/api/v1/members/me/account');
 	return response.data;
 };
+
+export const patchAccountInfo = async (): Promise<ApiResponse<null>> => {
+	const response = await api.patch('/api/v1/members/me/account');
+	return response.data;
+};

--- a/src/apis/account.ts
+++ b/src/apis/account.ts
@@ -1,3 +1,4 @@
+import { AccountInfoRequestDTO } from '@models/account/request/accountInfoRequestDTO';
 import { AccountInfoResponseDTO } from '@models/account/response/accountInfoResponseDTO';
 import { ApiResponse } from '@type/apiResponse';
 
@@ -10,7 +11,9 @@ export const getAccountInfo = async (): Promise<
 	return response.data;
 };
 
-export const patchAccountInfo = async (): Promise<ApiResponse<null>> => {
-	const response = await api.patch('/api/v1/members/me/account');
+export const patchAccountInfo = async (
+	data: AccountInfoRequestDTO,
+): Promise<ApiResponse<null>> => {
+	const response = await api.patch('/api/v1/members/me/account', data);
 	return response.data;
 };

--- a/src/apis/wishList.ts
+++ b/src/apis/wishList.ts
@@ -11,7 +11,7 @@ export const getWishListProductSimpleList = async (
 	return resposne.data;
 };
 
-export const postWishList = async (
+export const postWishItem = async (
 	itemId: number,
 ): Promise<ApiResponse<null>> => {
 	const response = await api.post(`api/v1/dib/${itemId}`);

--- a/src/apis/wishList.ts
+++ b/src/apis/wishList.ts
@@ -1,0 +1,12 @@
+import { ProductSimpleListResponseDTO } from '@models/product/response/productSimpleListResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+import { api } from '.';
+
+export const getWishListProductSimpleList = async (
+	page: number,
+): Promise<ApiResponse<ProductSimpleListResponseDTO>> => {
+	const params = { page };
+	const resposne = await api.get(`/api/v1/dib/me`, { params });
+	return resposne.data;
+};

--- a/src/apis/wishList.ts
+++ b/src/apis/wishList.ts
@@ -17,3 +17,10 @@ export const postWishItem = async (
 	const response = await api.post(`api/v1/dib/${itemId}`);
 	return response.data;
 };
+
+export const deleteWishItem = async (
+	itemId: number,
+): Promise<ApiResponse<null>> => {
+	const response = await api.delete(`api/v1/dib/${itemId}`);
+	return response.data;
+};

--- a/src/apis/wishList.ts
+++ b/src/apis/wishList.ts
@@ -10,3 +10,10 @@ export const getWishListProductSimpleList = async (
 	const resposne = await api.get(`/api/v1/dib/me`, { params });
 	return resposne.data;
 };
+
+export const postWishList = async (
+	itemId: number,
+): Promise<ApiResponse<null>> => {
+	const response = await api.post(`api/v1/dib/${itemId}`);
+	return response.data;
+};

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -31,7 +31,11 @@ const ProductCard = ({
 		setCurLike(isDib);
 	}, [isDib]);
 
-	const { mutate: postWishItem } = usePostWishItem();
+	const onErrorCallback = () => {
+		setCurLike(prev => !prev);
+	};
+
+	const { mutate: postWishItem } = usePostWishItem(undefined, onErrorCallback);
 	const { mutate: deleteWishItem } = useDeleteWithItem();
 
 	const Image = {
@@ -50,7 +54,6 @@ const ProductCard = ({
 				isFullHeart={curLike}
 				handleClickHeart={() => {
 					setCurLike(prev => !prev);
-					//TODO 실패한 경우 rollback하기
 					//TODO 요청 중 버튼 클릭 막기
 					if (curLike) {
 						deleteWishItem(id);

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -36,7 +36,10 @@ const ProductCard = ({
 	};
 
 	const { mutate: postWishItem } = usePostWishItem(undefined, onErrorCallback);
-	const { mutate: deleteWishItem } = useDeleteWithItem();
+	const { mutate: deleteWishItem } = useDeleteWithItem(
+		undefined,
+		onErrorCallback,
+	);
 
 	const Image = {
 		checkbox: <ImageWithCheck src={thumbnailUrl} alt={title} id={id} />,

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -1,5 +1,5 @@
 import { ImageWithCheck, ImageWithHeart, CardInfo } from '@components/atoms';
-import { usePostWithList } from '@hooks/apis/wishList';
+import { usePostWishItem } from '@hooks/apis/wishList';
 import { ProductSimple } from '@models/product/entity/product';
 import { useNavigate } from 'react-router-dom';
 
@@ -23,7 +23,7 @@ const ProductCard = ({
 		navigate(`/detail/${id}`);
 	};
 
-	const { mutate } = usePostWithList();
+	const { mutate } = usePostWishItem();
 
 	const Image = {
 		checkbox: <ImageWithCheck src={thumbnailUrl} alt={title} id={id} />,

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -1,4 +1,5 @@
 import { ImageWithCheck, ImageWithHeart, CardInfo } from '@components/atoms';
+import { usePostWithList } from '@hooks/apis/wishList';
 import { ProductSimple } from '@models/product/entity/product';
 import { useNavigate } from 'react-router-dom';
 
@@ -22,6 +23,8 @@ const ProductCard = ({
 		navigate(`/detail/${id}`);
 	};
 
+	const { mutate } = usePostWithList();
+
 	const Image = {
 		checkbox: <ImageWithCheck src={thumbnailUrl} alt={title} id={id} />,
 		default: (
@@ -37,7 +40,7 @@ const ProductCard = ({
 				alt={title}
 				isFullHeart={isDib}
 				handleClickHeart={() => {
-					console.log('heart');
+					mutate(id);
 				}}
 			/>
 		),

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { ImageWithCheck, ImageWithHeart, CardInfo } from '@components/atoms';
 import { usePostWishItem } from '@hooks/apis/wishList';
 import { ProductSimple } from '@models/product/entity/product';
@@ -23,6 +25,12 @@ const ProductCard = ({
 		navigate(`/detail/${id}`);
 	};
 
+	const [curLike, setCurLike] = useState<boolean>(isDib);
+
+	useEffect(() => {
+		setCurLike(isDib);
+	}, [isDib]);
+
 	const { mutate } = usePostWishItem();
 
 	const Image = {
@@ -38,9 +46,15 @@ const ProductCard = ({
 			<ImageWithHeart
 				src={thumbnailUrl}
 				alt={title}
-				isFullHeart={isDib}
+				isFullHeart={curLike}
 				handleClickHeart={() => {
-					mutate(id);
+					setCurLike(prev => !prev);
+					//TODO 실패한 경우 rollback하기
+					if (curLike) {
+						//TODO delete api 연동
+					} else {
+						mutate(id);
+					}
 				}}
 			/>
 		),

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { ImageWithCheck, ImageWithHeart, CardInfo } from '@components/atoms';
-import { usePostWishItem } from '@hooks/apis/wishList';
+import { useDeleteWithItem, usePostWishItem } from '@hooks/apis/wishList';
 import { ProductSimple } from '@models/product/entity/product';
 import { useNavigate } from 'react-router-dom';
 
@@ -31,7 +31,8 @@ const ProductCard = ({
 		setCurLike(isDib);
 	}, [isDib]);
 
-	const { mutate } = usePostWishItem();
+	const { mutate: postWishItem } = usePostWishItem();
+	const { mutate: deleteWishItem } = useDeleteWithItem();
 
 	const Image = {
 		checkbox: <ImageWithCheck src={thumbnailUrl} alt={title} id={id} />,
@@ -50,10 +51,11 @@ const ProductCard = ({
 				handleClickHeart={() => {
 					setCurLike(prev => !prev);
 					//TODO 실패한 경우 rollback하기
+					//TODO 요청 중 버튼 클릭 막기
 					if (curLike) {
-						//TODO delete api 연동
+						deleteWishItem(id);
 					} else {
-						mutate(id);
+						postWishItem(id);
 					}
 				}}
 			/>

--- a/src/components/templates/account/PreEditAccount.tsx
+++ b/src/components/templates/account/PreEditAccount.tsx
@@ -1,28 +1,20 @@
 import { DefaultButton } from '@components/atoms';
 import { DisabledAccountForm } from '@components/organisms';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
-import { mockAccountForm } from '@mocks/form';
 import { useAccountInfoStore } from '@stores/formInfoStore';
 import { useNavigate } from 'react-router-dom';
 
 const PreEditAccount = () => {
-	// TODO: api를 통해 사용자 account 정보 가져오기
-	const defaultValues = mockAccountForm;
-
-	const { setAccountInfo } = useAccountInfoStore();
-	const saveAccountInfo = () => {
-		setAccountInfo(defaultValues);
-	};
+	const { accountInfo } = useAccountInfoStore();
 
 	const navigate = useNavigate();
 	const handleRegisterAccountButtonClick = () => {
-		saveAccountInfo();
 		navigate('/progress-account/edit');
 	};
 
 	return (
 		<div className="flex flex-col">
-			<DisabledAccountForm defaultValues={defaultValues} />
+			<DisabledAccountForm defaultValues={accountInfo} />
 			<FixedBottomLayout childrenPadding="px-6" height="h-15">
 				<DefaultButton
 					title="수정하기"

--- a/src/hooks/apis/account.ts
+++ b/src/hooks/apis/account.ts
@@ -1,4 +1,5 @@
 import { getAccountInfo, patchAccountInfo } from '@apis/account';
+import { AccountInfoRequestDTO } from '@models/account/request/accountInfoRequestDTO';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetAccountInfo = () => {
@@ -14,7 +15,7 @@ export const usePatchAccountIfo = (
 	errorCallback?: (error: Error) => void,
 ) => {
 	return useMutation({
-		mutationFn: () => patchAccountInfo(),
+		mutationFn: (data: AccountInfoRequestDTO) => patchAccountInfo(data),
 		onSuccess: successCallback,
 		onError: errorCallback,
 	});

--- a/src/hooks/apis/account.ts
+++ b/src/hooks/apis/account.ts
@@ -1,0 +1,10 @@
+import { getAccountInfo } from '@apis/account';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useGetAccountInfo = () => {
+	return useSuspenseQuery({
+		queryKey: ['accountInfo'],
+		queryFn: () => getAccountInfo(),
+		select: data => data.data,
+	});
+};

--- a/src/hooks/apis/account.ts
+++ b/src/hooks/apis/account.ts
@@ -1,10 +1,21 @@
-import { getAccountInfo } from '@apis/account';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { getAccountInfo, patchAccountInfo } from '@apis/account';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetAccountInfo = () => {
 	return useSuspenseQuery({
 		queryKey: ['accountInfo'],
 		queryFn: () => getAccountInfo(),
 		select: data => data.data,
+	});
+};
+
+export const usePatchAccountIfo = (
+	successCallback?: () => void,
+	errorCallback?: (error: Error) => void,
+) => {
+	return useMutation({
+		mutationFn: () => patchAccountInfo(),
+		onSuccess: successCallback,
+		onError: errorCallback,
 	});
 };

--- a/src/hooks/apis/wishList.ts
+++ b/src/hooks/apis/wishList.ts
@@ -1,4 +1,8 @@
-import { getWishListProductSimpleList, postWishItem } from '@apis/wishList';
+import {
+	deleteWishItem,
+	getWishListProductSimpleList,
+	postWishItem,
+} from '@apis/wishList';
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
 export const useGetWishListProductSimpleList = () => {
@@ -19,6 +23,17 @@ export const usePostWishItem = (
 ) => {
 	return useMutation({
 		mutationFn: (itemId: number) => postWishItem(itemId),
+		onSuccess: successCallback,
+		onError: errorCallback,
+	});
+};
+
+export const useDeleteWithItem = (
+	successCallback?: () => void,
+	errorCallback?: (error: Error) => void,
+) => {
+	return useMutation({
+		mutationFn: (itemId: number) => deleteWishItem(itemId),
 		onSuccess: successCallback,
 		onError: errorCallback,
 	});

--- a/src/hooks/apis/wishList.ts
+++ b/src/hooks/apis/wishList.ts
@@ -1,5 +1,5 @@
-import { getWishListProductSimpleList } from '@apis/wishList';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { getWishListProductSimpleList, postWishList } from '@apis/wishList';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
 export const useGetWishListProductSimpleList = () => {
 	return useInfiniteQuery({
@@ -10,5 +10,16 @@ export const useGetWishListProductSimpleList = () => {
 			const nextPage = allPages.length + 1;
 			return lastPage?.data.isLastPage ? undefined : nextPage;
 		},
+	});
+};
+
+export const usePostWithList = (
+	successCallback?: () => void,
+	errorCallback?: (error: Error) => void,
+) => {
+	return useMutation({
+		mutationFn: (itemId: number) => postWishList(itemId),
+		onSuccess: successCallback,
+		onError: errorCallback,
 	});
 };

--- a/src/hooks/apis/wishList.ts
+++ b/src/hooks/apis/wishList.ts
@@ -1,0 +1,14 @@
+import { getWishListProductSimpleList } from '@apis/wishList';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export const useGetWishListProductSimpleList = () => {
+	return useInfiniteQuery({
+		queryKey: ['wishListProductSimpleList'],
+		queryFn: ({ pageParam = 1 }) => getWishListProductSimpleList(pageParam),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage, allPages) => {
+			const nextPage = allPages.length + 1;
+			return lastPage?.data.isLastPage ? undefined : nextPage;
+		},
+	});
+};

--- a/src/hooks/apis/wishList.ts
+++ b/src/hooks/apis/wishList.ts
@@ -1,4 +1,4 @@
-import { getWishListProductSimpleList, postWishList } from '@apis/wishList';
+import { getWishListProductSimpleList, postWishItem } from '@apis/wishList';
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
 export const useGetWishListProductSimpleList = () => {
@@ -13,12 +13,12 @@ export const useGetWishListProductSimpleList = () => {
 	});
 };
 
-export const usePostWithList = (
+export const usePostWishItem = (
 	successCallback?: () => void,
 	errorCallback?: (error: Error) => void,
 ) => {
 	return useMutation({
-		mutationFn: (itemId: number) => postWishList(itemId),
+		mutationFn: (itemId: number) => postWishItem(itemId),
 		onSuccess: successCallback,
 		onError: errorCallback,
 	});

--- a/src/models/account/request/accountInfoRequestDTO.ts
+++ b/src/models/account/request/accountInfoRequestDTO.ts
@@ -1,0 +1,3 @@
+import { AccountInfoResponseDTO } from '../response/accountInfoResponseDTO';
+
+export type AccountInfoRequestDTO = AccountInfoResponseDTO;

--- a/src/models/account/response/accountInfoResponseDTO.ts
+++ b/src/models/account/response/accountInfoResponseDTO.ts
@@ -1,5 +1,5 @@
 export type AccountInfoResponseDTO = {
-	depositorName: string | null;
-	account: string | null;
-	accountBank: string | null;
+	depositorName: string;
+	account: string;
+	accountBank: string;
 };

--- a/src/models/account/response/accountInfoResponseDTO.ts
+++ b/src/models/account/response/accountInfoResponseDTO.ts
@@ -1,0 +1,5 @@
+export type AccountInfoResponseDTO = {
+	depositorName: string | null;
+	account: string | null;
+	accountBank: string | null;
+};

--- a/src/pages/WishList.tsx
+++ b/src/pages/WishList.tsx
@@ -3,25 +3,24 @@ import {
 	DefaultWishListWithNoItem,
 	EditWishList,
 } from '@components/templates';
+import { useGetWishListProductSimpleList } from '@hooks/apis/wishList';
 import PageLayout from '@layouts/PageLayout';
-import { mockProductSimpleList } from '@mocks/mockProductSimpleList';
 import { useWishListStore } from '@stores/wishListStore';
 
 const WishList = () => {
 	const wishListStatus = useWishListStore(state => state.wishListStatus);
 
-	//TODO api 연동
-	const mockData = mockProductSimpleList;
+	const { data } = useGetWishListProductSimpleList();
 
 	const renderContent = () => {
-		if (wishListStatus === 'default') {
-			if (mockData.length > 0) {
-				return <DefaultWishList productList={mockData} />;
+		const productList = data?.pages[0].data.itemResponses;
+		if (productList && productList.length > 0) {
+			if (wishListStatus === 'default') {
+				return <DefaultWishList productList={productList} />;
 			}
-			return <DefaultWishListWithNoItem />;
+			return <EditWishList productList={productList} />;
 		}
-
-		return <EditWishList productList={mockData} />;
+		return <DefaultWishListWithNoItem />;
 	};
 	return (
 		<PageLayout leftType="home" className="h-full flex flex-col px-3 py-3">

--- a/src/pages/account/ReadAccountInfo.tsx
+++ b/src/pages/account/ReadAccountInfo.tsx
@@ -1,9 +1,23 @@
+import { useEffect } from 'react';
+
 import { PreEditAccount, PreRegisterAccount } from '@components/templates';
 import { useGetAccountInfo } from '@hooks/apis/account';
 import PageLayout from '@layouts/PageLayout';
+import { useAccountInfoStore } from '@stores/formInfoStore';
 
 const ReadAccountInfo = () => {
 	const { data: accountInfo } = useGetAccountInfo();
+	const setAccountInfo = useAccountInfoStore(state => state.setAccountInfo);
+
+	useEffect(() => {
+		if (accountInfo) {
+			setAccountInfo({
+				USER: accountInfo.depositorName,
+				BANK: accountInfo.accountBank,
+				ACCOUNT: accountInfo.account,
+			});
+		}
+	}, [accountInfo]);
 
 	const renderAccountInfo = () => {
 		if (accountInfo.account) {

--- a/src/pages/account/ReadAccountInfo.tsx
+++ b/src/pages/account/ReadAccountInfo.tsx
@@ -1,14 +1,12 @@
 import { PreEditAccount, PreRegisterAccount } from '@components/templates';
+import { useGetAccountInfo } from '@hooks/apis/account';
 import PageLayout from '@layouts/PageLayout';
 
 const ReadAccountInfo = () => {
-	// TODO: api를 통해 계좌 정보 가져오기
-	// data가 있는 형태는 아래 주석을 풀고 사용하세요.
-	// const accountInfo = mockAccountForm;
-	const accountInfo = null;
+	const { data: accountInfo } = useGetAccountInfo();
 
 	const renderAccountInfo = () => {
-		if (accountInfo) {
+		if (accountInfo.account) {
 			return <PreEditAccount />;
 		}
 

--- a/src/pages/account/SaveAccountInfo.tsx
+++ b/src/pages/account/SaveAccountInfo.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { DefaultButton, RequestLeaveModalButton } from '@components/atoms';
 import { DisabledAccountForm } from '@components/organisms';
+import { usePatchAccountIfo } from '@hooks/apis/account';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
 import PageLayout from '@layouts/PageLayout';
 import { useAccountInfoStore } from '@stores/formInfoStore';
@@ -9,10 +10,15 @@ import { useNavigate } from 'react-router-dom';
 
 const SaveAccountInfo = () => {
 	const { accountInfo, clearAccountInfo, enterType } = useAccountInfoStore();
-
+	const { mutate } = usePatchAccountIfo();
 	const navigate = useNavigate();
+
 	const handleRegisterAccountButtonClick = () => {
-		// TODO: api를 통해 submit 날리기
+		mutate({
+			depositorName: accountInfo.USER,
+			account: accountInfo.ACCOUNT,
+			accountBank: accountInfo.BANK,
+		});
 		navigate('/my-page');
 	};
 


### PR DESCRIPTION
### **요약 (Summary)**
- 찜 및 계좌 관련 api를 연동합니다.

### **목표 (Goals)**
- 찜 post, delete api 연동
- 찜 페이지 불러오기 api 연동
- 계좌 정보 불러오기 api 연동
- 계좌 정보 수정하기 api 연동

### **목표가 아닌 것 (Non-Goals)**
- 찜 페이지에서 삭제하는 경우, 현재 api가 하나의 아이템에 대해서만 삭제가 가능하여 서버님께 수정 요청을 드린 상태입니다. 따라서 추후 수정할 예정입니다.

### **계획 (Plan)**
찜 버튼 클릭 시, React query를 통해 낙관적 업데이트를 하고자 하였으나 홈에서 아이템이 매번 랜덤으로 불러와지므로 react query를 사용할 수 없었습니다. 따라서, 상태 관리를 통해 버튼 클릭시 UI에 바로 반영이 되도록 하였습니다.
