### PR TITLE
Feat#232.검색 및 포인트 출금 api 연동

### DIFF
--- a/src/apis/point.ts
+++ b/src/apis/point.ts
@@ -24,3 +24,13 @@ export const getCumulatedPoint = async (): Promise<
 	const response = await api.get('/api/v1/points/history/cumulate');
 	return response.data;
 };
+
+export const postPointWithdraw = async (
+	refund: number,
+): Promise<ApiResponse<PointHistoryResponseDTO>> => {
+	const params = {
+		refund,
+	};
+	const response = await api.post('/api/v1/points/withdraw', null, { params });
+	return response.data;
+};

--- a/src/apis/search.ts
+++ b/src/apis/search.ts
@@ -1,0 +1,16 @@
+import { ProductSimpleListResponseDTO } from '@models/product/response/productSimpleListResponseDTO';
+import { ApiResponse } from '@type/apiResponse';
+
+import { api } from '.';
+
+export const search = async (
+	page: number,
+	keyword: string,
+): Promise<ApiResponse<ProductSimpleListResponseDTO>> => {
+	const params = {
+		page,
+		keyword,
+	};
+	const response = await api.get('/api/v1/search', { params });
+	return response.data;
+};

--- a/src/components/atoms/BuyWithLikeButton.tsx
+++ b/src/components/atoms/BuyWithLikeButton.tsx
@@ -1,18 +1,15 @@
 import { Button } from 'konsta/react';
 
-import { IconButton } from '@components/atoms';
+import { HeartButton } from '@components/atoms';
 import { useNavigate } from 'react-router-dom';
 
 type LikeButtonProps = {
+	id: number;
 	isDib: boolean;
 };
 
-const BuyWithLikeButton = ({ isDib }: LikeButtonProps) => {
+const BuyWithLikeButton = ({ id, isDib }: LikeButtonProps) => {
 	const navigate = useNavigate();
-
-	const handleLikeClick = () => {
-		console.log('현재 상품 찜 등록 및 삭제하기');
-	};
 
 	const handleBuyClick = () => {
 		navigate('/notification');
@@ -20,13 +17,11 @@ const BuyWithLikeButton = ({ isDib }: LikeButtonProps) => {
 
 	return (
 		<div className="w-full flex gap-6">
-			<IconButton
+			<HeartButton
+				id={id}
+				isDib={isDib}
+				size={32}
 				className="!w-8 !px-0 !py-4"
-				icon={{
-					id: isDib ? 'like-full' : 'like-empty',
-					size: 32,
-				}}
-				onClick={handleLikeClick}
 			/>
 			<Button
 				className="w-full h-[38px] k-color-Primary !text-White !typography-Btn_text1 text-center rounded-sm"

--- a/src/components/atoms/BuyWithLikeButton.tsx
+++ b/src/components/atoms/BuyWithLikeButton.tsx
@@ -4,10 +4,10 @@ import { IconButton } from '@components/atoms';
 import { useNavigate } from 'react-router-dom';
 
 type LikeButtonProps = {
-	like: boolean;
+	isDib: boolean;
 };
 
-const BuyWithLikeButton = ({ like }: LikeButtonProps) => {
+const BuyWithLikeButton = ({ isDib }: LikeButtonProps) => {
 	const navigate = useNavigate();
 
 	const handleLikeClick = () => {
@@ -23,7 +23,7 @@ const BuyWithLikeButton = ({ like }: LikeButtonProps) => {
 			<IconButton
 				className="!w-8 !px-0 !py-4"
 				icon={{
-					id: like ? 'like-full' : 'like-empty',
+					id: isDib ? 'like-full' : 'like-empty',
 					size: 32,
 				}}
 				onClick={handleLikeClick}

--- a/src/components/atoms/SearchTextField.tsx
+++ b/src/components/atoms/SearchTextField.tsx
@@ -34,7 +34,6 @@ const SearchTextField = ({
 	};
 
 	const location = useLocation();
-	console.log(location);
 
 	useEffect(() => {
 		if (searchValue === '' && location.pathname === '/search') {

--- a/src/components/atoms/SearchTextField.tsx
+++ b/src/components/atoms/SearchTextField.tsx
@@ -1,10 +1,10 @@
-import { useState, KeyboardEvent } from 'react';
+import { useState, KeyboardEvent, useEffect } from 'react';
 
 import { IconButton } from '@components/atoms';
 import { SvgIcon } from '@components/common';
 import colors from '@constants/colors';
 import { useSearchHistoryStore } from '@stores/searchHistoryStore';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 type SearchTextFieldProps = {
 	isFocused?: boolean;
@@ -31,8 +31,16 @@ const SearchTextField = ({
 
 	const handleClearSearchValue = () => {
 		setSearchValue('');
-		navigate('/search');
 	};
+
+	const location = useLocation();
+	console.log(location);
+
+	useEffect(() => {
+		if (searchValue === '' && location.pathname === '/search') {
+			navigate('/search', { replace: true });
+		}
+	}, [searchValue]);
 
 	const [searchParams, setSearchParams] = useSearchParams();
 	const addSearchQuery = useSearchHistoryStore(state => state.addSearchQuery);

--- a/src/components/atoms/ToastMessageLikeOrDelete.tsx
+++ b/src/components/atoms/ToastMessageLikeOrDelete.tsx
@@ -2,14 +2,19 @@ import { Button } from 'konsta/react';
 
 import { SvgIcon } from '@components/common';
 import colors from '@constants/colors';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 
 type ToastMessageLikeOrDeleteProps = {
 	like: boolean;
 };
 
 const ToastMessageLikeOrDelete = ({ like }: ToastMessageLikeOrDeleteProps) => {
+	const navigate = useNavigate();
+
 	const handleClick = () => {
-		console.log('찜 목록 가기');
+		toast.remove();
+		navigate('/wish-list');
 	};
 
 	const toastPadding = like ? 'px-3 py-1.5' : 'px-1.5 py-4 text-center';

--- a/src/components/atoms/button/HeartButton.tsx
+++ b/src/components/atoms/button/HeartButton.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import { IconButton } from '@components/index';
+import { IconButton, ToastMessageLikeOrDelete } from '@components/index';
 import { useDeleteWithItem, usePostWishItem } from '@hooks/apis/wishList';
+import toast from 'react-hot-toast';
 
 type HeartButtonProps = {
 	id: number;
@@ -28,6 +29,9 @@ const HeartButton = ({ id, isDib, size, className }: HeartButtonProps) => {
 	);
 
 	const handleLikeHeart = () => {
+		toast(() => <ToastMessageLikeOrDelete like={!curLike} />, {
+			duration: 2000,
+		});
 		setCurLike(prev => !prev);
 		//TODO 요청 중 버튼 클릭 막기
 		if (curLike) {

--- a/src/components/atoms/button/HeartButton.tsx
+++ b/src/components/atoms/button/HeartButton.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+import { IconButton } from '@components/index';
+import { useDeleteWithItem, usePostWishItem } from '@hooks/apis/wishList';
+
+type HeartButtonProps = {
+	id: number;
+	isDib: boolean;
+	size: number;
+	className?: string;
+};
+
+const HeartButton = ({ id, isDib, size, className }: HeartButtonProps) => {
+	const [curLike, setCurLike] = useState<boolean>(isDib);
+
+	useEffect(() => {
+		setCurLike(isDib);
+	}, [isDib]);
+
+	const onErrorCallback = () => {
+		setCurLike(prev => !prev);
+	};
+
+	const { mutate: postWishItem } = usePostWishItem(undefined, onErrorCallback);
+	const { mutate: deleteWishItem } = useDeleteWithItem(
+		undefined,
+		onErrorCallback,
+	);
+
+	const handleLikeHeart = () => {
+		setCurLike(prev => !prev);
+		//TODO 요청 중 버튼 클릭 막기
+		if (curLike) {
+			deleteWishItem(id);
+		} else {
+			postWishItem(id);
+		}
+	};
+	return (
+		<IconButton
+			className={className}
+			icon={{
+				id: curLike ? 'like-full' : 'like-empty',
+				size,
+			}}
+			onClick={handleLikeHeart}
+		/>
+	);
+};
+
+export default HeartButton;

--- a/src/components/atoms/card/ImageWithHeart.tsx
+++ b/src/components/atoms/card/ImageWithHeart.tsx
@@ -1,29 +1,23 @@
-import { IconButton } from '@components/atoms';
-import colors from '@constants/colors';
+// import { IconButton } from '@components/atoms';
+// import colors from '@constants/colors';
+
+import { HeartButton } from '@components/atoms';
 
 type ImageWithCheckProps = {
 	src: string;
 	alt: string;
-	isFullHeart?: boolean;
-	handleClickHeart: () => void;
+	id: number;
+	isDib: boolean;
 };
 
-const ImageWithHeart = ({
-	src,
-	alt,
-	handleClickHeart,
-	isFullHeart = false,
-}: ImageWithCheckProps) => {
+const ImageWithHeart = ({ src, alt, id, isDib }: ImageWithCheckProps) => {
 	return (
 		<div className="relative rounded-[5px] overflow-hidden w-full aspect-square">
 			<img src={src} alt={alt} className="w-full h-full" />
-			<IconButton
-				icon={{
-					id: isFullHeart ? 'like-full' : 'like-empty',
-					size: 24,
-					color: colors.Primary,
-				}}
-				onClick={handleClickHeart}
+			<HeartButton
+				id={id}
+				isDib={isDib}
+				size={24}
 				className="!w-fit !h-fit absolute top-1 right-1 z-10 !p-0"
 			/>
 		</div>

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -22,6 +22,7 @@ export { default as RequestVerificationButton } from './button/RequestVerificati
 export { default as RequestLeaveModalButton } from './button/RequestLeaveModalButton';
 export { default as KakaoLoginButton } from './button/KakaoLoginButton';
 export { default as AppleLoginButton } from './button/AppleLoginButton';
+export { default as HeartButton } from './button/HeartButton';
 
 export { default as CardInfo } from './card/CardInfo';
 export { default as ImageWithCheck } from './card/ImageWithCheck';

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useState } from 'react';
-
 import { ImageWithCheck, ImageWithHeart, CardInfo } from '@components/atoms';
-import { useDeleteWithItem, usePostWishItem } from '@hooks/apis/wishList';
 import { ProductSimple } from '@models/product/entity/product';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,22 +22,6 @@ const ProductCard = ({
 		navigate(`/detail/${id}`);
 	};
 
-	const [curLike, setCurLike] = useState<boolean>(isDib);
-
-	useEffect(() => {
-		setCurLike(isDib);
-	}, [isDib]);
-
-	const onErrorCallback = () => {
-		setCurLike(prev => !prev);
-	};
-
-	const { mutate: postWishItem } = usePostWishItem(undefined, onErrorCallback);
-	const { mutate: deleteWishItem } = useDeleteWithItem(
-		undefined,
-		onErrorCallback,
-	);
-
 	const Image = {
 		checkbox: <ImageWithCheck src={thumbnailUrl} alt={title} id={id} />,
 		default: (
@@ -51,20 +32,7 @@ const ProductCard = ({
 			/>
 		),
 		heart: (
-			<ImageWithHeart
-				src={thumbnailUrl}
-				alt={title}
-				isFullHeart={curLike}
-				handleClickHeart={() => {
-					setCurLike(prev => !prev);
-					//TODO 요청 중 버튼 클릭 막기
-					if (curLike) {
-						deleteWishItem(id);
-					} else {
-						postWishItem(id);
-					}
-				}}
-			/>
+			<ImageWithHeart src={thumbnailUrl} alt={title} id={id} isDib={isDib} />
 		),
 	};
 

--- a/src/components/molecules/point/PointHeader.tsx
+++ b/src/components/molecules/point/PointHeader.tsx
@@ -1,11 +1,19 @@
+import { useEffect } from 'react';
+
 import {
 	GroupOrderTextPoint,
 	RequestVerificationButton,
 } from '@components/atoms';
 import { useGetCurrentPoint } from '@hooks/apis/point';
+import { setHeldPoint } from '@utils/localStorage/point';
 
 const PointHeader = () => {
 	const { data: totalPoint } = useGetCurrentPoint();
+	useEffect(() => {
+		if (typeof totalPoint === 'number') {
+			setHeldPoint(totalPoint);
+		}
+	}, [totalPoint]);
 
 	return (
 		<div className="flex justify-between items-end mb-7">

--- a/src/components/templates/search/PostSearch.tsx
+++ b/src/components/templates/search/PostSearch.tsx
@@ -1,7 +1,7 @@
 import { SearchTextField } from '@components/atoms';
 import { PostSearchHeader } from '@components/molecules';
 import { ProductCardList } from '@components/organisms';
-import { mockSearchResultData } from '@mocks/search';
+import { useSearch } from '@hooks/apis/search';
 import { SearchQuery } from '@type/searchQuery';
 
 type PostSearchProps = {
@@ -9,15 +9,17 @@ type PostSearchProps = {
 };
 
 const PostSearch = ({ searchQuery }: PostSearchProps) => {
-	// TODO: searchQuery에 대해 api 호출
-	const searchResultList = mockSearchResultData.searchResultList;
+	const { data } = useSearch(searchQuery);
 
 	return (
 		<>
 			<SearchTextField defaultValue={searchQuery} />
 			<PostSearchHeader />
 			<div className="my-3">
-				<ProductCardList type="heart" productList={searchResultList} />
+				<ProductCardList
+					type="heart"
+					productList={data?.pages[0].data.itemResponses}
+				/>
 			</div>
 		</>
 	);

--- a/src/components/templates/wishList/DefaultWishList.tsx
+++ b/src/components/templates/wishList/DefaultWishList.tsx
@@ -4,13 +4,21 @@ import { ProductSimpleList } from '@models/product/entity/product';
 
 type DefaultWishListProps = {
 	productList: ProductSimpleList;
+	totalProductLength: number;
 };
 
-const DefaultWishList = ({ productList }: DefaultWishListProps) => {
+const DefaultWishList = ({
+	productList,
+	totalProductLength,
+}: DefaultWishListProps) => {
 	return (
 		<>
 			<DefaultWishListHeader />
 			<div className="my-3">
+				<h4 className="typography-Body4 typography-R text-White">
+					검색 결과 <span className="text-Primary">{totalProductLength}</span>{' '}
+					개
+				</h4>
 				<ProductCardList type="default" productList={productList} />
 			</div>
 		</>

--- a/src/components/templates/withdrawal/PreWithdrawal.tsx
+++ b/src/components/templates/withdrawal/PreWithdrawal.tsx
@@ -1,5 +1,7 @@
 import { GroupOrderTextPoint, DefaultButton } from '@components/atoms';
+import { useGetAccountInfo } from '@hooks/apis/account';
 import FixedBottomLayout from '@layouts/FixedBottomLayout';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 const PreWithdrawal = () => {
@@ -12,25 +14,24 @@ const PreWithdrawal = () => {
 		navigate('/withdrawal/progress');
 	};
 
-	// TODO api로 값 받아오기 (은행 정보, 계좌 번호, 누적 포인트)
-	const accountBank = '국민은행';
-	const accountNumber = '123456789';
-	const point = '1000';
+	const queryClient = useQueryClient();
+	const { data } = useGetAccountInfo();
+	const point = queryClient.getQueryData(['currentPoint']);
 
 	return (
 		<div className="typography-Body1 typography-R text-White flex flex-col gap-12 h-full">
 			<div className="flex flex-col">
 				회원님의 계좌는
-				<span className="typography-Headline">{accountBank}</span>
+				<span className="typography-Headline">{data.accountBank}</span>
 				<div className="flex items-end gap-2">
-					<span className="typography-Headline">{accountNumber}</span>
+					<span className="typography-Headline">{data.account}</span>
 					입니다.
 				</div>
 			</div>
 			<div className="flex flex-col">
 				회원님의 누적 포인트는
 				<div className="flex items-end gap-2">
-					<GroupOrderTextPoint point={point} />
+					<GroupOrderTextPoint point={String(point)} />
 					입니다.
 				</div>
 			</div>

--- a/src/components/templates/withdrawal/ProgressWithdrawal.tsx
+++ b/src/components/templates/withdrawal/ProgressWithdrawal.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { Form, RequestLeaveModalButton } from '@components/atoms';
 import { usePostPointWithdraw } from '@hooks/apis/point';
 import { useAccountInfoStore } from '@stores/formInfoStore';
+import { useQueryClient } from '@tanstack/react-query';
 import { FormType, pointSchema } from '@type/form';
 import { useNavigate } from 'react-router-dom';
 
@@ -23,6 +24,20 @@ const ProgressWithdrawal = () => {
 			mutate(data.POINT);
 		}
 	};
+
+	const queryClient = useQueryClient();
+	const point = queryClient.getQueryData(['currentPoint']);
+
+	console.log(pointSchema);
+
+	const updatedPointSchema = pointSchema.refine(data => {
+		if (typeof point === 'number') {
+			return data.POINT < point;
+		}
+		return false;
+	}, '보유한 포인트를 초과했어요.');
+
+	console.log(updatedPointSchema);
 
 	return (
 		<div className="text-White flex flex-col gap-6">

--- a/src/components/templates/withdrawal/ProgressWithdrawal.tsx
+++ b/src/components/templates/withdrawal/ProgressWithdrawal.tsx
@@ -1,13 +1,27 @@
+import { useEffect } from 'react';
+
 import { Form, RequestLeaveModalButton } from '@components/atoms';
+import { usePostPointWithdraw } from '@hooks/apis/point';
+import { useAccountInfoStore } from '@stores/formInfoStore';
 import { FormType, pointSchema } from '@type/form';
 import { useNavigate } from 'react-router-dom';
 
 const ProgressWithdrawal = () => {
+	const { setIsSelectedBankNeeded } = useAccountInfoStore();
+	useEffect(() => {
+		setIsSelectedBankNeeded(false);
+	}, [setIsSelectedBankNeeded]);
+
 	const navigate = useNavigate();
-	const onSubmit = (data: FormType) => {
-		// data api 처리 후 navigate하도록 코드 변경
-		console.log(data);
+	const onSuccessCallback = () => {
 		navigate('/withdrawal/post', { replace: true });
+	};
+	const { mutate } = usePostPointWithdraw(onSuccessCallback);
+
+	const onSubmit = (data: FormType) => {
+		if ('POINT' in data) {
+			mutate(data.POINT);
+		}
 	};
 
 	return (

--- a/src/constants/localStorageKey.ts
+++ b/src/constants/localStorageKey.ts
@@ -3,6 +3,7 @@ const enum LocalStorageKey {
 	REFRESH_TOKEN = 'refreshToken',
 	USER_NAME = 'userName',
 	PROVIDER = 'provider',
+	HELD_POINT = 'heldPoint',
 }
 
 export default LocalStorageKey;

--- a/src/hooks/apis/point.ts
+++ b/src/hooks/apis/point.ts
@@ -2,8 +2,9 @@ import {
 	getCumulatedPoint,
 	getCurrentPoint,
 	getExpectedPoint,
+	postPointWithdraw,
 } from '@apis/point';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetCurrentPoint = () => {
 	return useSuspenseQuery({
@@ -26,5 +27,16 @@ export const useGetCumulatedPoint = () => {
 		queryKey: ['cumulatedPoint'],
 		queryFn: () => getCumulatedPoint(),
 		select: data => data.data,
+	});
+};
+
+export const usePostPointWithdraw = (
+	successCallback?: () => void,
+	errorCallback?: (error: Error) => void,
+) => {
+	return useMutation({
+		mutationFn: (refund: number) => postPointWithdraw(refund),
+		onSuccess: successCallback,
+		onError: errorCallback,
 	});
 };

--- a/src/hooks/apis/search.ts
+++ b/src/hooks/apis/search.ts
@@ -1,0 +1,14 @@
+import { search } from '@apis/search';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export const useSearch = (keyword: string) => {
+	return useInfiniteQuery({
+		queryKey: ['search'],
+		queryFn: ({ pageParam = 1 }) => search(pageParam, keyword),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage, allPages) => {
+			const nextPage = allPages.length + 1;
+			return lastPage?.data.isLastPage ? undefined : nextPage;
+		},
+	});
+};

--- a/src/models/point/entity/point.ts
+++ b/src/models/point/entity/point.ts
@@ -4,8 +4,12 @@ export type Point = string;
 
 export type PointHistory = {
 	id: number;
-	refund?: Point;
+	refund: Point;
 	uploadTime: string;
+	approvedTime: string;
+	pointsBeforeRefund: number;
+	pointsAfterRefund: number;
+	purchase: number;
 	refundStatus: RefundStatus;
 };
 

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -99,7 +99,7 @@ const ProductDetail = () => {
 				childrenPadding={'py-3 pl-4 pr-3'}
 				bottom="bottom-0"
 			>
-				<BuyWithLikeButton isDib={isDib} />
+				<BuyWithLikeButton id={productIdAsNumber} isDib={isDib} />
 			</FixedBottomLayout>
 		</PageLayout>
 	);

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -99,7 +99,7 @@ const ProductDetail = () => {
 				childrenPadding={'py-3 pl-4 pr-3'}
 				bottom="bottom-0"
 			>
-				<BuyWithLikeButton like={isDib} />
+				<BuyWithLikeButton isDib={isDib} />
 			</FixedBottomLayout>
 		</PageLayout>
 	);

--- a/src/pages/WishList.tsx
+++ b/src/pages/WishList.tsx
@@ -16,7 +16,10 @@ const WishList = () => {
 		const productList = data?.pages[0].data.itemResponses;
 		if (productList && productList.length > 0) {
 			if (wishListStatus === 'default') {
-				return <DefaultWishList productList={productList} />;
+				// TODO totalProductLength 응답에서 가져오기
+				return (
+					<DefaultWishList productList={productList} totalProductLength={10} />
+				);
 			}
 			return <EditWishList productList={productList} />;
 		}

--- a/src/pages/WithdrawalResult.tsx
+++ b/src/pages/WithdrawalResult.tsx
@@ -1,30 +1,34 @@
 import { DefaultKeyValueContainer } from '@components/molecules';
+import { useGetImageUploadDetailList } from '@hooks/apis/imageUpload';
 import PageLayout from '@layouts/PageLayout';
-import mockWithdrawalResult from '@mocks/mockWithdrawalResult';
 import { getDataInYYYYMMDDSplitedByDot, getPointText } from '@utils/formatData';
+import { useParams } from 'react-router-dom';
 
 const WithdrawalResult = () => {
+	const { resultId } = useParams();
+	const { data } = useGetImageUploadDetailList(Number(resultId));
+
 	return (
 		<PageLayout className="px-6 py-5 flex flex-col gap-6" leftType="back">
 			<DefaultKeyValueContainer
 				title="환금 요청 일시"
-				value={getDataInYYYYMMDDSplitedByDot(mockWithdrawalResult.requestDate)}
+				value={getDataInYYYYMMDDSplitedByDot(data.uploadTime)}
 			/>
 			<DefaultKeyValueContainer
 				title="환금 승인 일시"
-				value={getDataInYYYYMMDDSplitedByDot(mockWithdrawalResult.approvedDate)}
+				value={getDataInYYYYMMDDSplitedByDot(data.approvedTime)}
 			/>
 			<DefaultKeyValueContainer
 				title="환급 전 누적포인트"
-				value={getPointText(mockWithdrawalResult.prevPoint)}
+				value={getPointText(String(data.pointsBeforeRefund))}
 			/>
 			<DefaultKeyValueContainer
 				title="요청 포인트"
-				value={getPointText(mockWithdrawalResult.requestPoint)}
+				value={getPointText(String(data.refund))}
 			/>
 			<DefaultKeyValueContainer
 				title="잔여 포인트"
-				value={getPointText(mockWithdrawalResult.remainedPoint)}
+				value={getPointText(String(data.pointsAfterRefund))}
 			/>
 		</PageLayout>
 	);

--- a/src/stories/atoms/BuyWithLikeButton.stories.tsx
+++ b/src/stories/atoms/BuyWithLikeButton.stories.tsx
@@ -25,12 +25,12 @@ type Story = StoryObj<typeof meta>;
 
 export const LikeOn: Story = {
 	args: {
-		like: true,
+		isDib: true,
 	},
 };
 
 export const LikeOff: Story = {
 	args: {
-		like: false,
+		isDib: false,
 	},
 };

--- a/src/stories/atoms/BuyWithLikeButton.stories.tsx
+++ b/src/stories/atoms/BuyWithLikeButton.stories.tsx
@@ -25,12 +25,14 @@ type Story = StoryObj<typeof meta>;
 
 export const LikeOn: Story = {
 	args: {
+		id: 1,
 		isDib: true,
 	},
 };
 
 export const LikeOff: Story = {
 	args: {
+		id: 2,
 		isDib: false,
 	},
 };

--- a/src/type/form.ts
+++ b/src/type/form.ts
@@ -1,12 +1,21 @@
 import * as z from 'zod';
 
+import { getHeldPoint } from '@utils/localStorage/point';
+
 export const pointSchema = z.object({
 	POINT: z
 		.string()
 		.min(1, '필수 입력 사항입니다.')
 		.transform(value => +value.replace(/[^0-9]/g, ''))
 		.refine(value => value <= 5000, '최대 금액이 5,000 P에요.')
-		.refine(value => value >= 1000, '최소 금액이 1,000 P에요.'),
+		.refine(value => value >= 1000, '최소 금액이 1,000 P에요.')
+		.refine(value => {
+			const point = getHeldPoint();
+			if (typeof point === 'number') {
+				return value < point;
+			}
+			return false;
+		}, '보유한 포인트를 초과했어요.'),
 });
 
 export const accountSchema = z.object({

--- a/src/type/form.ts
+++ b/src/type/form.ts
@@ -5,8 +5,8 @@ export const pointSchema = z.object({
 		.string()
 		.min(1, '필수 입력 사항입니다.')
 		.transform(value => +value.replace(/[^0-9]/g, ''))
-		.refine(value => value < 5000, '최대 금액이 5,000 P에요.')
-		.refine(value => value > 1000, '최소 금액이 1,000 P에요.'),
+		.refine(value => value <= 5000, '최대 금액이 5,000 P에요.')
+		.refine(value => value >= 1000, '최소 금액이 1,000 P에요.'),
 });
 
 export const accountSchema = z.object({

--- a/src/utils/localStorage/point.ts
+++ b/src/utils/localStorage/point.ts
@@ -1,0 +1,8 @@
+import LocalStorageKey from '@constants/localStorageKey';
+
+export const getHeldPoint = () =>
+	localStorage.getItem(LocalStorageKey.HELD_POINT);
+export const setHeldPoint = (point: string) =>
+	localStorage.setItem(LocalStorageKey.HELD_POINT, point);
+export const removeHeldPoint = () =>
+	localStorage.removeItem(LocalStorageKey.HELD_POINT);

--- a/src/utils/localStorage/point.ts
+++ b/src/utils/localStorage/point.ts
@@ -1,8 +1,13 @@
 import LocalStorageKey from '@constants/localStorageKey';
 
-export const getHeldPoint = () =>
-	localStorage.getItem(LocalStorageKey.HELD_POINT);
-export const setHeldPoint = (point: string) =>
-	localStorage.setItem(LocalStorageKey.HELD_POINT, point);
+export const getHeldPoint = () => {
+	const point = localStorage.getItem(LocalStorageKey.HELD_POINT);
+	if (point) {
+		return parseInt(point, 10);
+	}
+	return null;
+};
+export const setHeldPoint = (point: number) =>
+	localStorage.setItem(LocalStorageKey.HELD_POINT, point.toString());
 export const removeHeldPoint = () =>
 	localStorage.removeItem(LocalStorageKey.HELD_POINT);


### PR DESCRIPTION
### **요약 (Summary)**
검색 및 포인트 출금 api을 연동합니다.

### **목표 (Goals)**
- 검색 api 연동
- 포인트 출금 api 연동
- 찜 버튼 클릭시 토스트 메시지 생성
- searchTextField에서 searchValue가 없을 때 /search로 이동
- 포인트 출금시, 보유한 포인트보다 초과할 경우 helperText 띄우기

### **목표가 아닌 것 (Non-Goals)**
- 검색 결과 / 찜 갯수에 대해서는 api 수정이 필요하여 다음 태스크로 미루었습니다.

### **계획 (Plan)**
보유한 포인트보다 초과할 경우에 대한 form 처리도 필요할 것 같아 schema에 추가하였습니다. zod schema의 경우 동적 할당은 되지 않는 것 같고, 전역 상태로 관리되는 값을 가져오기도 힘든 구조라 보유 포인트 값을 가져오기 위한 방법을 모색했습니다. pointSchema를 컴포넌트 내로 가지고 와서 .refine으로 업데이트를 하고자 하였으나 타입이 zodObject가 아닌 zodEffect로 바뀌어 실패했습니다. 따라서 어쩔 수 없이 로컬 스토리지를 써서 구현하게 되었는데, 좋은 방법이 있으면 알려주세요
