### PR TITLE
Feature#244.토큰 만료 유저 처리

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -5,6 +5,7 @@ import axios, {
 } from 'axios';
 
 import { ApiResponse } from '@type/apiResponse';
+import { removeServiceAccountCache } from '@utils/localStorage/removeServiceAccountCache';
 import {
 	getAccessToken,
 	getRefreshToken,
@@ -46,6 +47,7 @@ const onResponseRejected = async (error: AxiosError) => {
 	if (error.response?.status === 401) {
 		const errorCode = (error.response?.data as ApiResponse<null>)?.errorCode;
 		if (errorCode === '401/0001') {
+			removeServiceAccountCache();
 			window.location.href = '/sign-up';
 		} else if (errorCode === '401/0002') {
 			const { data } = await api.post('/api/v1/auth/refresh-access-token', {

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -7,11 +7,8 @@ import axios, {
 import { ApiResponse } from '@type/apiResponse';
 import {
 	getAccessToken,
-	getRefreshToken,
 	renewAccessToken,
-	setAccessToken,
-	setRefreshToken,
-	verifyAccessToken,
+	renewRefreshToken,
 } from '@utils/localStorage/token';
 
 export const api = axios.create({
@@ -24,15 +21,13 @@ export const api = axios.create({
 });
 
 const onRequestFulfilled = async (config: InternalAxiosRequestConfig) => {
-	let accessToken = getAccessToken();
-
-	if (!verifyAccessToken()) {
-		renewAccessToken();
-		accessToken = getAccessToken();
-	}
+	const accessToken = getAccessToken();
 
 	if (accessToken && config.headers) {
 		config.headers['Authorization'] = `Bearer ${accessToken}`;
+	} else {
+		const superToken = import.meta.env.VITE_SUPER_TOKEN;
+		config.headers['Authorization'] = `Bearer ${superToken}`;
 	}
 
 	return config;
@@ -53,17 +48,9 @@ const onResponseRejected = async (error: AxiosError) => {
 	if (error.response?.status === 401) {
 		const errorCode = (error.response?.data as ApiResponse<null>)?.errorCode;
 		if (errorCode === '401/0001') {
-			renewAccessToken();
+			renewRefreshToken();
 		} else if (errorCode === '401/0002') {
-			const { data } = await api.post('/api/v1/auth/refresh-access-token', {
-				refreshToken: getRefreshToken(),
-			});
-
-			const newAccessToken = data.accessToken;
-			const newRefreshToken = data.refreshToken;
-
-			setAccessToken(newAccessToken);
-			setRefreshToken(newRefreshToken);
+			const newAccessToken = await renewAccessToken();
 
 			requestConfig.headers['Authorization'] = `Bearer ${newAccessToken}`;
 

--- a/src/components/common/ProvidersTree.tsx
+++ b/src/components/common/ProvidersTree.tsx
@@ -13,6 +13,7 @@ const queryClient = new QueryClient({
 		queries: {
 			throwOnError: true,
 			refetchOnWindowFocus: false,
+			retry: false,
 		},
 		mutations: {
 			throwOnError: true,

--- a/src/utils/localStorage/token.ts
+++ b/src/utils/localStorage/token.ts
@@ -1,3 +1,4 @@
+import { api } from '@apis/index';
 import LocalStorageKey from '@constants/localStorageKey';
 import { removeServiceAccountCache } from '@utils/localStorage/removeServiceAccountCache';
 
@@ -44,7 +45,21 @@ export const verifyRefreshToken = () => {
 	return false;
 };
 
-export const renewAccessToken = () => {
+export const renewAccessToken = async () => {
+	const { data } = await api.post('/api/v1/auth/refresh-access-token', {
+		refreshToken: getRefreshToken(),
+	});
+
+	const newAccessToken = data.accessToken;
+	const newRefreshToken = data.refreshToken;
+
+	setAccessToken(newAccessToken);
+	setRefreshToken(newRefreshToken);
+
+	return newAccessToken;
+};
+
+export const renewRefreshToken = () => {
 	removeServiceAccountCache();
 	window.location.href = '/sign-up';
 };

--- a/src/utils/localStorage/token.ts
+++ b/src/utils/localStorage/token.ts
@@ -1,4 +1,5 @@
 import LocalStorageKey from '@constants/localStorageKey';
+import { removeServiceAccountCache } from '@utils/localStorage/removeServiceAccountCache';
 
 export const getAccessToken = () =>
 	localStorage.getItem(LocalStorageKey.ACCESS_TOKEN);
@@ -13,3 +14,37 @@ export const setRefreshToken = (refreshToken: string) =>
 	localStorage.setItem(LocalStorageKey.REFRESH_TOKEN, refreshToken);
 export const removeRefreshToken = () =>
 	localStorage.removeItem(LocalStorageKey.REFRESH_TOKEN);
+
+const parseJwt = (token: string) => {
+	return JSON.parse(atob(token.split('.')[1]));
+};
+
+export const verifyToken = (token: string) => {
+	const parsedToken = parseJwt(token);
+	const exp = parsedToken.exp;
+	const now = new Date().getTime() / 1000;
+	return now < exp;
+};
+
+export const verifyAccessToken = () => {
+	const accessToken = getAccessToken();
+	if (accessToken) {
+		return verifyToken(accessToken);
+	}
+
+	return false;
+};
+
+export const verifyRefreshToken = () => {
+	const refreshToken = getRefreshToken();
+	if (refreshToken) {
+		return verifyToken(refreshToken);
+	}
+
+	return false;
+};
+
+export const renewAccessToken = () => {
+	removeServiceAccountCache();
+	window.location.href = '/sign-up';
+};


### PR DESCRIPTION
### **요약 (Summary)**

토큰 만료 처리를 프론트 단에서도 진행하려 했으나 api 요청을 10만개 이상 날리는 오류가 발생하였고, 토큰 만료에 대한 서버 api 오류가 수정되었기 때문에 해당 작업을 후순위로 미뤄도 될 것 같습니다.

### **목표 (Goals)**

- api가 모두 token이 존재해야하도록 수정되었기 때문에 super token을 추가하여 모두가 token을 가지도록 보장
- 기존 access token과 refresh 토큰 재발급 코드를 분리함
- token을 parse하여 validation을 확인하는 코드 작성
