### PR TITLE
fix: 환금 오타 수정

### DIFF
--- a/src/components/templates/withdrawalResult/WithdrawalResultCompleted.tsx
+++ b/src/components/templates/withdrawalResult/WithdrawalResultCompleted.tsx
@@ -12,11 +12,11 @@ const WithdrawalResultCompleted = ({ data }: WithdrawalResultProps) => {
 	return (
 		<div className="px-6 py-5 flex flex-col gap-6">
 			<DefaultKeyValueContainer
-				title="환금 요청 일시"
+				title="환급 요청 일시"
 				value={getDataInYYYYMMDDSplitedByDot(data.uploadTime)}
 			/>
 			<DefaultKeyValueContainer
-				title="환금 승인 일시"
+				title="환급 승인 일시"
 				value={getDataInYYYYMMDDSplitedByDot(data.approvedTime)}
 			/>
 			<KeyValueContainer

--- a/src/components/templates/withdrawalResult/WithdrawalResultInProgress.tsx
+++ b/src/components/templates/withdrawalResult/WithdrawalResultInProgress.tsx
@@ -9,10 +9,10 @@ const WithdrawalResultInProgress = ({ data }: WithdrawalResultProps) => {
 	return (
 		<div className="px-6 py-5 flex flex-col gap-6">
 			<DefaultKeyValueContainer
-				title="환금 요청 일시"
+				title="환급 요청 일시"
 				value={getDataInYYYYMMDDSplitedByDot(data.uploadTime)}
 			/>
-			<DefaultKeyValueContainer title="환금 승인 일시" value="-" />
+			<DefaultKeyValueContainer title="환급 승인 일시" value="-" />
 			<KeyValueContainer
 				title="승인 여부"
 				value={statusTag[data.refundStatus]}

--- a/src/components/templates/withdrawalResult/WithdrawalResultRejected.tsx
+++ b/src/components/templates/withdrawalResult/WithdrawalResultRejected.tsx
@@ -9,11 +9,11 @@ const WithdrawalResultRejected = ({ data }: WithdrawalResultProps) => {
 	return (
 		<div className="px-6 py-5 flex flex-col gap-6">
 			<DefaultKeyValueContainer
-				title="환금 요청 일시"
+				title="환급 요청 일시"
 				value={getDataInYYYYMMDDSplitedByDot(data.uploadTime)}
 			/>
 			<DefaultKeyValueContainer
-				title="환금 승인 일시"
+				title="환급 승인 일시"
 				value={getDataInYYYYMMDDSplitedByDot(data.approvedTime)}
 			/>
 			<KeyValueContainer


### PR DESCRIPTION
### **요약 (Summary)**
디자인 단에서 오타가 있어 수정합니다.
포인트 상세 페이지의 '환금' 오타를 '환급'으로 수정하였습니다.

### **목표 (Goals)**
사용자에게 명확한 용어를 전달합니다.






